### PR TITLE
Add the Badge Component

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -48,6 +48,20 @@
       ]
     },
     {
+      "name": "badge",
+      "type": "registry:ui",
+      "title": "Badge",
+      "description": "Small status/label chip with variants, composable via Base UI's render prop.",
+      "dependencies": ["@base-ui-components/react", "class-variance-authority"],
+      "registryDependencies": ["utils"],
+      "files": [
+        {
+          "path": "registry/nebari/ui/badge.tsx",
+          "type": "registry:ui"
+        }
+      ]
+    },
+    {
       "name": "theme",
       "type": "registry:theme",
       "title": "Nebari theme",
@@ -76,6 +90,7 @@
           "destructive-foreground": "oklch(0.55 0.215 27.4)",
           "border": "oklch(0.922 0 0)",
           "input": "oklch(0.922 0 0)",
+          "border-strong": "oklch(0.781 0.006 288.8)",
           "ring": "oklch(0.5809 0.2683 319.62)",
           "chart-1": "oklch(0.5809 0.2683 319.62)",
           "chart-2": "oklch(0.6679 0.1102 187.93)",
@@ -111,6 +126,7 @@
           "destructive-foreground": "oklch(0.7802 0.1024 27.78)",
           "border": "oklch(1 0 0 / 10%)",
           "input": "oklch(1 0 0 / 15%)",
+          "border-strong": "oklch(1 0 0 / 20%)",
           "ring": "oklch(0.6809 0.2483 319.62)",
           "chart-1": "oklch(0.6809 0.2483 319.62)",
           "chart-2": "oklch(0.6679 0.1102 187.93)",

--- a/registry/nebari/globals.css
+++ b/registry/nebari/globals.css
@@ -43,6 +43,9 @@
 
   --border: oklch(0.922 0 0);
   --input: oklch(0.922 0 0);
+  /* Figma token color/border/default (#b7b7bb) — a stronger, more visible
+   * border than the default (used by the Badge outline variant). */
+  --border-strong: oklch(0.781 0.006 288.8);
   --ring: oklch(0.5809 0.2683 319.62);
 
   --chart-1: oklch(0.5809 0.2683 319.62);
@@ -92,6 +95,7 @@
 
   --border: oklch(1 0 0 / 10%);
   --input: oklch(1 0 0 / 15%);
+  --border-strong: oklch(1 0 0 / 20%);
   --ring: oklch(0.6809 0.2483 319.62);
 
   --chart-1: oklch(0.6809 0.2483 319.62);
@@ -138,6 +142,7 @@
 
   --color-border: var(--border);
   --color-input: var(--input);
+  --color-border-strong: var(--border-strong);
   --color-ring: var(--ring);
 
   --color-chart-1: var(--chart-1);

--- a/registry/nebari/ui/badge.tsx
+++ b/registry/nebari/ui/badge.tsx
@@ -1,0 +1,54 @@
+import { useRender } from '@base-ui-components/react/use-render';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '@/lib/utils';
+
+const badgeVariants = cva(
+  "inline-flex w-fit shrink-0 items-center justify-center gap-1 whitespace-nowrap rounded-full border border-transparent px-1.5 py-0.5 font-medium text-xs leading-4 underline-offset-4 outline-none transition-colors hover:underline focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-3",
+  {
+    variants: {
+      variant: {
+        default:
+          'bg-primary text-primary-foreground hover:bg-primary-hover active:bg-primary-hover',
+        secondary: 'bg-muted text-muted-foreground',
+        destructive: 'bg-destructive text-destructive-foreground',
+        outline: 'border-border-strong bg-background text-foreground',
+        ghost: 'text-foreground',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  },
+);
+
+interface BadgeProps
+  extends useRender.ComponentProps<'span'>,
+    VariantProps<typeof badgeVariants> {}
+
+/**
+ * Badge implemented from the Nebari Figma spec — a small status/label chip.
+ * Variants are driven by `class-variance-authority`; polymorphism is provided
+ * by Base UI's `render` prop, so a `Badge` can become a link (or any element)
+ * while keeping its styling (`<Badge render={<a href="…" />}>`).
+ */
+function Badge({
+  className,
+  variant,
+  ref,
+  render = <span />,
+  ...props
+}: BadgeProps) {
+  return useRender({
+    render,
+    ref,
+    props: {
+      className: cn(badgeVariants({ variant }), className),
+      'data-slot': 'badge',
+      'data-variant': variant ?? 'default',
+      ...props,
+    },
+  });
+}
+
+export type { BadgeProps };
+export { Badge, badgeVariants };

--- a/stories/badge.stories.tsx
+++ b/stories/badge.stories.tsx
@@ -1,0 +1,113 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { ExternalLink } from 'lucide-react';
+import { Badge } from '@/ui/badge';
+
+const meta = {
+  title: 'Components/Badge',
+  component: Badge,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'Badge implemented from the Nebari Figma spec — a small chip for statuses, counts, and tags. Variants are driven by `class-variance-authority`; polymorphism is provided by Base UI’s `render` prop, so a `Badge` can become a link (or any element) while keeping its styling.',
+      },
+    },
+  },
+  args: { children: 'Badge' },
+  argTypes: {
+    variant: {
+      description: 'Visual style of the badge.',
+      control: 'select',
+      options: ['default', 'secondary', 'destructive', 'outline', 'ghost'],
+      table: { defaultValue: { summary: 'default' } },
+    },
+    children: {
+      description:
+        'Badge content — text, and optionally a leading/trailing icon.',
+      control: 'text',
+    },
+  },
+} satisfies Meta<typeof Badge>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  name: 'Default',
+  parameters: {
+    docs: {
+      description: {
+        story: 'The default badge — solid primary fill.',
+      },
+    },
+  },
+};
+
+export const Variants: Story = {
+  name: 'Variants',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'All five visual styles. `destructive` is a soft tinted style (not solid red); `outline` is unfilled with a border; `ghost` is unfilled with no border.',
+      },
+    },
+  },
+  render: (args) => (
+    <div className="flex flex-wrap items-center gap-3">
+      <Badge {...args} variant="default">
+        Default
+      </Badge>
+      <Badge {...args} variant="secondary">
+        Secondary
+      </Badge>
+      <Badge {...args} variant="destructive">
+        Destructive
+      </Badge>
+      <Badge {...args} variant="outline">
+        Outline
+      </Badge>
+      <Badge {...args} variant="ghost">
+        Ghost
+      </Badge>
+    </div>
+  ),
+};
+
+export const WithIcon: Story = {
+  name: 'With icon',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'An icon can lead or trail the label; the gap is handled by the badge.',
+      },
+    },
+  },
+  render: (args) => (
+    <Badge {...args} variant="secondary">
+      Link
+      <ExternalLink />
+    </Badge>
+  ),
+};
+
+export const AsLink: Story = {
+  name: 'Render as link',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Via Base UI’s `render` prop the badge becomes an `<a>` while keeping all of its styling and slot attributes.',
+      },
+    },
+  },
+  render: (args) => (
+    // biome-ignore lint/a11y/useAnchorContent: Badge injects children into the rendered anchor.
+    <Badge {...args} render={<a href="https://nebari.dev" />}>
+      nebari.dev
+    </Badge>
+  ),
+};

--- a/tests/badge.test.tsx
+++ b/tests/badge.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { Badge, badgeVariants } from '@/ui/badge';
+
+describe('Badge', () => {
+  it('renders its children with default variant data attributes', () => {
+    render(<Badge>New</Badge>);
+
+    const badge = screen.getByText('New');
+    expect(badge).toHaveAttribute('data-slot', 'badge');
+    expect(badge).toHaveAttribute('data-variant', 'default');
+    expect(badge).toHaveClass('bg-primary', 'text-primary-foreground');
+  });
+
+  it('applies the secondary variant classes', () => {
+    render(<Badge variant="secondary">Beta</Badge>);
+
+    const badge = screen.getByText('Beta');
+    expect(badge).toHaveAttribute('data-variant', 'secondary');
+    expect(badge).toHaveClass('bg-muted', 'text-muted-foreground');
+  });
+
+  it('applies the destructive variant classes (soft fill + strong text)', () => {
+    render(<Badge variant="destructive">Error</Badge>);
+
+    const badge = screen.getByText('Error');
+    expect(badge).toHaveAttribute('data-variant', 'destructive');
+    // Destructive uses the explicit Figma feedback pair, not an opacity tint.
+    expect(badge).toHaveClass('bg-destructive', 'text-destructive-foreground');
+  });
+
+  it('applies the outline variant classes (bordered, unfilled)', () => {
+    render(<Badge variant="outline">Draft</Badge>);
+
+    const badge = screen.getByText('Draft');
+    expect(badge).toHaveAttribute('data-variant', 'outline');
+    expect(badge).toHaveClass('border-border-strong', 'text-foreground');
+  });
+
+  it('applies the ghost variant classes (no fill, no border)', () => {
+    render(<Badge variant="ghost">Tag</Badge>);
+
+    const badge = screen.getByText('Tag');
+    expect(badge).toHaveAttribute('data-variant', 'ghost');
+    expect(badge).toHaveClass('text-foreground');
+    expect(badge).not.toHaveClass('border-border-strong');
+  });
+
+  it('composes as a different element via the render prop', () => {
+    // biome-ignore lint/a11y/useAnchorContent: Badge injects children into the rendered anchor.
+    render(<Badge render={<a href="/tags/new" />}>New</Badge>);
+
+    const link = screen.getByRole('link', { name: 'New' });
+    expect(link).toHaveAttribute('href', '/tags/new');
+    // Styling and slot attributes carry over to the rendered element.
+    expect(link).toHaveClass('bg-primary');
+    expect(link).toHaveAttribute('data-slot', 'badge');
+  });
+
+  it('exposes badgeVariants for external composition', () => {
+    const classes = badgeVariants({ variant: 'outline' });
+    expect(classes).toContain('border-border-strong');
+    expect(classes).toContain('rounded-full');
+  });
+});


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://nebari.dev/community
-->

## Reference Issues or PRs

Fixes #27

## What does this implement/fix?

_Put a `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [x] Did you test the pull request locally?
- [x] Did you add new tests?

## Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Nebari Internals docs.
  - If no docs exist:
    - Create a stub for documentation, including bullet points for how to use the feature, code snippets (including from
      happy path tests), etc.
We want to ensure that the content produced for Nebari is accessible; if you are making significant contributions,
please address the access-centred guidelines in your content and complete our checklist. Thanks to @isabela-pf for this checklist :)
-->

### Access-centered content checklist

#### Text styling

- [ ] The content is written with [plain language](https://www.plainlanguage.gov/guidelines/) (where relevant).
- [ ] If there are headers, they use the proper header tags (with only one level-one header: `H1` or `#` in markdown).
- [ ] All links describe where they link to (for example, check the [Nebari website](https://nebari.dev/)).
- [ ] This content adheres to the Nebari style guides.

#### Non-text content

- [ ] All content is represented as text (for example, images need alt text, and videos need captions or descriptive transcripts).
- [ ] If there are emojis, there are not more than three in a row.
- [ ] Don't use [flashing GIFs or videos](https://www.w3.org/TR/UNDERSTANDING-WCAG20/seizure-does-not-violate.html).
- [ ] If the content were to be read as plain text, it still makes sense, and no information is missing.

## Any other comments?
<img width="1728" height="875" alt="Screenshot 2026-06-17 at 1 44 33 PM" src="https://github.com/user-attachments/assets/2ce89465-815f-43e1-83a5-6b7bc3f56309" />

<!--
Please be aware that we are a loose team of volunteers, so patience is necessary;
assistance handling other issues is very welcome.
We value all user contributions. If we are slow to review, either the pull request needs some benchmarking, tinkering,
convincing, etc., or the reviewers are likely busy. In either case,
we ask for your understanding during the
review process.
Thanks for contributing to Nebari 🙏🏼!
-->
