### PR TITLE
orientation controlls for the radio group and checkbox buttons

### DIFF
--- a/registry/nebari/ui/checkbox.tsx
+++ b/registry/nebari/ui/checkbox.tsx
@@ -1,8 +1,21 @@
 import { Checkbox as CheckboxPrimitive } from '@base-ui-components/react/checkbox';
+import { CheckboxGroup as CheckboxGroupPrimitive } from '@base-ui-components/react/checkbox-group';
 import { cva, type VariantProps } from 'class-variance-authority';
 import { CheckIcon, MinusIcon } from 'lucide-react';
 import { type ReactNode, useId } from 'react';
 import { cn } from '@/lib/utils';
+
+const checkboxGroupVariants = cva('w-full rounded-sm', {
+  variants: {
+    orientation: {
+      vertical: 'grid gap-3',
+      horizontal: 'flex flex-wrap items-start gap-x-5 gap-y-3',
+    },
+  },
+  defaultVariants: {
+    orientation: 'vertical',
+  },
+});
 
 const checkboxVariants = cva(
   'group/checkbox inline-flex cursor-pointer select-none items-start gap-2 text-left text-foreground outline-none active:text-muted-foreground-strong',
@@ -20,6 +33,15 @@ const checkboxVariants = cva(
   },
 );
 
+type CheckboxGroupOrientation = NonNullable<
+  VariantProps<typeof checkboxGroupVariants>['orientation']
+>;
+
+type CheckboxGroupProps = Omit<CheckboxGroupPrimitive.Props, 'orientation'> & {
+  /** Controls whether checkbox items stack vertically or wrap horizontally. */
+  orientation?: CheckboxGroupOrientation;
+};
+
 type CheckboxProps = Omit<
   CheckboxPrimitive.Root.Props,
   'children' | 'className'
@@ -30,6 +52,27 @@ type CheckboxProps = Omit<
     /** Supplementary text exposed as the checkbox's accessible description. */
     description?: ReactNode;
   };
+
+/** Groups related checkboxes and controls their vertical or horizontal layout. */
+function CheckboxGroup({
+  className,
+  orientation = 'vertical',
+  ...props
+}: CheckboxGroupProps) {
+  return (
+    <CheckboxGroupPrimitive
+      {...props}
+      className={(state) =>
+        cn(
+          checkboxGroupVariants({ orientation }),
+          typeof className === 'function' ? className(state) : className,
+        )
+      }
+      data-orientation={orientation}
+      data-slot="checkbox-group"
+    />
+  );
+}
 
 /**
  * Checkbox implemented from the Nebari Figma spec on top of Base UI.
@@ -156,5 +199,5 @@ function Checkbox({
   );
 }
 
-export type { CheckboxProps };
-export { Checkbox, checkboxVariants };
+export type { CheckboxGroupProps, CheckboxProps };
+export { Checkbox, CheckboxGroup, checkboxGroupVariants, checkboxVariants };

--- a/registry/nebari/ui/radio-group.tsx
+++ b/registry/nebari/ui/radio-group.tsx
@@ -20,7 +20,26 @@ const radioGroupItemVariants = cva(
   },
 );
 
-type RadioGroupProps = RadioGroupPrimitive.Props;
+const radioGroupVariants = cva('w-full rounded-sm', {
+  variants: {
+    orientation: {
+      vertical: 'grid gap-3',
+      horizontal: 'flex flex-wrap items-start gap-x-5 gap-y-3',
+    },
+  },
+  defaultVariants: {
+    orientation: 'vertical',
+  },
+});
+
+type RadioGroupOrientation = NonNullable<
+  VariantProps<typeof radioGroupVariants>['orientation']
+>;
+
+type RadioGroupProps = Omit<RadioGroupPrimitive.Props, 'orientation'> & {
+  /** Controls whether radio items stack vertically or wrap horizontally. */
+  orientation?: RadioGroupOrientation;
+};
 
 type RadioGroupItemProps = Omit<RadioPrimitive.Root.Props, 'children'> &
   VariantProps<typeof radioGroupItemVariants> & {
@@ -31,16 +50,21 @@ type RadioGroupItemProps = Omit<RadioPrimitive.Root.Props, 'children'> &
   };
 
 /** Provides mutually-exclusive selection state to a set of radio items. */
-function RadioGroup({ className, ...props }: RadioGroupProps) {
+function RadioGroup({
+  className,
+  orientation = 'vertical',
+  ...props
+}: RadioGroupProps) {
   return (
     <RadioGroupPrimitive
       {...props}
       className={(state) =>
         cn(
-          'grid w-full gap-3 rounded-sm',
+          radioGroupVariants({ orientation }),
           typeof className === 'function' ? className(state) : className,
         )
       }
+      data-orientation={orientation}
       data-slot="radio-group"
     />
   );
@@ -157,4 +181,9 @@ function RadioGroupItem({
 }
 
 export type { RadioGroupItemProps, RadioGroupProps };
-export { RadioGroup, RadioGroupItem, radioGroupItemVariants };
+export {
+  RadioGroup,
+  RadioGroupItem,
+  radioGroupItemVariants,
+  radioGroupVariants,
+};

--- a/stories/checkbox.stories.tsx
+++ b/stories/checkbox.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import type { ComponentProps } from 'react';
 import { useState } from 'react';
-import { Checkbox } from '@/ui/checkbox';
+import { Checkbox, CheckboxGroup } from '@/ui/checkbox';
 import { Field, FieldDescription, FieldError, FieldLabel } from '@/ui/field';
 
 type CheckboxVariant = NonNullable<ComponentProps<typeof Checkbox>['variant']>;
@@ -66,7 +66,7 @@ const meta = {
     docs: {
       description: {
         component:
-          'Checkbox implemented from the Nebari Figma spec on top of Base UI. `Checkbox` represents a single boolean field with `default` (inline) and `box` (card) layouts. Compose with `Field` to add a standalone field label, description, and validation message.',
+          'Checkbox implemented from the Nebari Figma spec on top of Base UI. `Checkbox` represents a single boolean field with `default` (inline) and `box` (card) layouts. Use `CheckboxGroup` with `orientation="horizontal"` or `orientation="vertical"` to lay out related checkbox fields. Compose with `Field` to add a standalone field label, description, and validation message.',
       },
     },
   },
@@ -114,6 +114,22 @@ export const WithDescription: Story = {
         Enable automatic updates
       </Checkbox>
     </div>
+  ),
+};
+
+/**
+ * Use `CheckboxGroup` with `orientation="horizontal"` to arrange related
+ * checkbox fields in a wrapping row.
+ */
+export const Horizontal: Story = {
+  render: () => (
+    <CheckboxGroup aria-label="Workspace features" orientation="horizontal">
+      <Checkbox defaultChecked value="notebooks">
+        Notebooks
+      </Checkbox>
+      <Checkbox value="dashboards">Dashboards</Checkbox>
+      <Checkbox value="jobs">Jobs</Checkbox>
+    </CheckboxGroup>
   ),
 };
 

--- a/stories/radio-group.stories.tsx
+++ b/stories/radio-group.stories.tsx
@@ -70,6 +70,22 @@ export const WithDescription: Story = {
 };
 
 /**
+ * Use `orientation="horizontal"` to arrange related radio options in a
+ * wrapping row. The group still owns the single-selection behavior.
+ */
+export const Horizontal: Story = {
+  render: () => (
+    <div className="w-[28rem]">
+      <RadioGroup aria-label="Plan" defaultValue="pro" orientation="horizontal">
+        <RadioGroupItem value="starter">Starter</RadioGroupItem>
+        <RadioGroupItem value="pro">Pro</RadioGroupItem>
+        <RadioGroupItem value="team">Team</RadioGroupItem>
+      </RadioGroup>
+    </div>
+  ),
+};
+
+/**
  * The `box` variant turns each option into a bordered, fully clickable card.
  * Reach for it when options carry more content or need a larger hit target.
  */

--- a/tests/checkbox.test.tsx
+++ b/tests/checkbox.test.tsx
@@ -1,9 +1,45 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
-import { Checkbox, checkboxVariants } from '@/ui/checkbox';
+import {
+  Checkbox,
+  CheckboxGroup,
+  checkboxGroupVariants,
+  checkboxVariants,
+} from '@/ui/checkbox';
 
 describe('Checkbox', () => {
+  it('renders a vertical checkbox group by default', () => {
+    render(
+      <CheckboxGroup aria-label="Workspace features">
+        <Checkbox value="notebooks">Notebooks</Checkbox>
+      </CheckboxGroup>,
+    );
+
+    const group = screen.getByRole('group', {
+      name: 'Workspace features',
+    });
+    expect(group).toHaveAttribute('data-slot', 'checkbox-group');
+    expect(group).toHaveAttribute('data-orientation', 'vertical');
+    expect(group).toHaveClass('grid', 'gap-3');
+  });
+
+  it('lays out a checkbox group horizontally when requested', () => {
+    render(
+      <CheckboxGroup aria-label="Workspace features" orientation="horizontal">
+        <Checkbox value="notebooks">Notebooks</Checkbox>
+        <Checkbox value="dashboards">Dashboards</Checkbox>
+      </CheckboxGroup>,
+    );
+
+    const group = screen.getByRole('group', {
+      name: 'Workspace features',
+    });
+    expect(group).toHaveAttribute('data-orientation', 'horizontal');
+    expect(group).toHaveClass('flex', 'flex-wrap', 'gap-x-5', 'gap-y-3');
+    expect(group).not.toHaveClass('grid');
+  });
+
   it('renders the default, unchecked variant with stable data hooks', () => {
     render(<Checkbox description="A description">Checkbox Text</Checkbox>);
 
@@ -152,9 +188,12 @@ describe('Checkbox', () => {
   });
 
   it('exposes interaction classes and checkboxVariants', () => {
+    const groupClasses = checkboxGroupVariants({ orientation: 'horizontal' });
     const defaultClasses = checkboxVariants({ variant: 'default' });
     const boxClasses = checkboxVariants({ variant: 'box' });
 
+    expect(groupClasses).toContain('flex');
+    expect(groupClasses).toContain('gap-x-5');
     expect(defaultClasses).not.toContain('motion-safe:');
     expect(defaultClasses).toContain('focus-visible:ring-offset-2');
     expect(defaultClasses).toContain('rounded-[2px]');

--- a/tests/radio-group.test.tsx
+++ b/tests/radio-group.test.tsx
@@ -6,6 +6,7 @@ import {
   RadioGroup,
   RadioGroupItem,
   radioGroupItemVariants,
+  radioGroupVariants,
 } from '@/ui/radio-group';
 
 describe('RadioGroup', () => {
@@ -21,6 +22,7 @@ describe('RadioGroup', () => {
     const group = screen.getByRole('radiogroup', { name: 'Plan' });
     const radio = screen.getByRole('radio', { name: 'Starter' });
     expect(group).toHaveAttribute('data-slot', 'radio-group');
+    expect(group).toHaveAttribute('data-orientation', 'vertical');
     expect(group).toHaveClass('grid', 'gap-3');
     expect(radio).toHaveAttribute('data-slot', 'radio-group-item');
     expect(radio).toHaveAttribute('data-variant', 'default');
@@ -118,6 +120,20 @@ describe('RadioGroup', () => {
       'gap-5',
     );
     expect(screen.getByRole('radio', { name: 'Starter' })).toHaveClass('p-4');
+  });
+
+  it('lays out the group horizontally when requested', () => {
+    render(
+      <RadioGroup aria-label="Plan" orientation="horizontal">
+        <RadioGroupItem value="starter">Starter</RadioGroupItem>
+        <RadioGroupItem value="pro">Pro</RadioGroupItem>
+      </RadioGroup>,
+    );
+
+    const group = screen.getByRole('radiogroup', { name: 'Plan' });
+    expect(group).toHaveAttribute('data-orientation', 'horizontal');
+    expect(group).toHaveClass('flex', 'flex-wrap', 'gap-x-5', 'gap-y-3');
+    expect(group).not.toHaveClass('grid');
   });
 
   it('does not select a disabled item', async () => {
@@ -248,9 +264,12 @@ describe('RadioGroup', () => {
   });
 
   it('exposes interaction classes and radioGroupItemVariants', () => {
+    const groupClasses = radioGroupVariants({ orientation: 'horizontal' });
     const defaultClasses = radioGroupItemVariants({ variant: 'default' });
     const boxClasses = radioGroupItemVariants({ variant: 'box' });
 
+    expect(groupClasses).toContain('flex');
+    expect(groupClasses).toContain('gap-x-5');
     expect(defaultClasses).not.toContain('motion-safe:');
     expect(defaultClasses).toContain('focus-visible:border-ring');
     expect(defaultClasses).toContain('rounded-sm');


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://nebari.dev/community
-->

## Reference Issues or PRs

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create a link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

## What does this implement/fix?

_Put a `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [x] Did you test the pull request locally?
- [x] Did you add new tests?

## Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Nebari Internals docs.
  - If no docs exist:
    - Create a stub for documentation, including bullet points for how to use the feature, code snippets (including from
      happy path tests), etc.
We want to ensure that the content produced for Nebari is accessible; if you are making significant contributions,
please address the access-centred guidelines in your content and complete our checklist. Thanks to @isabela-pf for this checklist :)
-->

### Access-centered content checklist

#### Text styling

- [ ] The content is written with [plain language](https://www.plainlanguage.gov/guidelines/) (where relevant).
- [ ] If there are headers, they use the proper header tags (with only one level-one header: `H1` or `#` in markdown).
- [ ] All links describe where they link to (for example, check the [Nebari website](https://nebari.dev/)).
- [ ] This content adheres to the Nebari style guides.

#### Non-text content

- [ ] All content is represented as text (for example, images need alt text, and videos need captions or descriptive transcripts).
- [ ] If there are emojis, there are not more than three in a row.
- [ ] Don't use [flashing GIFs or videos](https://www.w3.org/TR/UNDERSTANDING-WCAG20/seizure-does-not-violate.html).
- [ ] If the content were to be read as plain text, it still makes sense, and no information is missing.

## Any other comments?

<!--
Please be aware that we are a loose team of volunteers, so patience is necessary;
assistance handling other issues is very welcome.
We value all user contributions. If we are slow to review, either the pull request needs some benchmarking, tinkering,
convincing, etc., or the reviewers are likely busy. In either case,
we ask for your understanding during the
review process.
Thanks for contributing to Nebari 🙏🏼!
-->
