### PR TITLE
Fix Shadcn CLI/Nebari Design Issue

### DIFF
--- a/.claude/skills/nebari-component/SKILL.md
+++ b/.claude/skills/nebari-component/SKILL.md
@@ -144,7 +144,7 @@ Add an item to the `items` array:
   "title": "Button",
   "description": "Button with variant and size options, composable via Base UI's render prop.",
   "dependencies": ["@base-ui-components/react", "class-variance-authority"],
-  "registryDependencies": ["utils"],
+  "registryDependencies": ["@nebari/utils"],
   "files": [
     {
       "path": "registry/nebari/ui/button.tsx",
@@ -165,13 +165,17 @@ Add an item to the `items` array:
 **`registryDependencies`** = other items the component needs from a registry.
 
 - Any component that calls `cn()` imports `@/lib/utils`, so it **must** list
-  `"utils"`.
-- Reference items in *this* registry by bare name (`"utils"`, `"theme"`); reference
-  the upstream shadcn registry by URL or `@scope/name`.
-- If the component relies on tokens that aren't guaranteed present, list `"theme"`
-  too. **Any component that uses motion tokens (`--duration-*`, `--ease-*`,
-  `--animate-*`) must list `"theme"` in `registryDependencies`** so `shadcn add`
-  installs those variables automatically.
+  `"@nebari/utils"`.
+- **Reference items in *this* registry by their `@nebari/<name>` namespace, not
+  by bare name** (`"@nebari/utils"`, `"@nebari/theme"`); reference the upstream
+  shadcn registry by URL or `@scope/name`. A bare `"theme"` makes the shadcn CLI
+  resolve against the default registry's `styles/<style>/theme.json` — a 404 that
+  aborts `shadcn add` for consumers — whereas `"@nebari/theme"` resolves through
+  the `@nebari` registry the consumer already has configured.
+- If the component relies on tokens that aren't guaranteed present, list
+  `"@nebari/theme"` too. **Any component that uses motion tokens (`--duration-*`,
+  `--ease-*`, `--animate-*`) must list `"@nebari/theme"` in `registryDependencies`**
+  so `shadcn add` installs those variables automatically.
 
 ## Motion
 
@@ -280,10 +284,10 @@ For panels that slide in from an edge (drawer, sheet), swap `translate-y-1` for
 ### `registry.json` reminder
 
 A component that references motion tokens (`--duration-*`, `--ease-*`,
-`--animate-*`) must list `"theme"` in `registryDependencies`:
+`--animate-*`) must list `"@nebari/theme"` in `registryDependencies`:
 
 ```json
-"registryDependencies": ["utils", "theme"]
+"registryDependencies": ["@nebari/utils", "@nebari/theme"]
 ```
 
 ## Step 3 — the story

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,8 +107,12 @@ rules that are easy to get wrong:
   **not** list `react`/`react-dom`, `tailwindcss`, or `clsx`/`tailwind-merge`
   (those belong to the `utils` item).
 - `registryDependencies` = other registry items. Anything that calls `cn()` must
-  list `"utils"`; if it depends on tokens that may be absent, also list
-  `"theme"`. Reference in-repo items by bare name.
+  list `"@nebari/utils"`; if it depends on tokens that may be absent, also list
+  `"@nebari/theme"`. **Reference in-repo items by their `@nebari/<name>`
+  namespace, not by bare name** — the shadcn CLI resolves a bare `"theme"`
+  against the default registry's `styles/<style>/theme.json` (a 404 that aborts
+  `shadcn add` for consumers), whereas `"@nebari/theme"` resolves through the
+  `@nebari` registry the consumer already has configured.
 
 ## Styling &amp; theming
 

--- a/registry.json
+++ b/registry.json
@@ -21,7 +21,7 @@
       "title": "Spinner",
       "description": "Animated loading spinner built on lucide-react.",
       "dependencies": ["lucide-react"],
-      "registryDependencies": ["utils"],
+      "registryDependencies": ["@nebari/utils"],
       "files": [
         {
           "path": "registry/nebari/ui/spinner.tsx",
@@ -39,7 +39,11 @@
         "class-variance-authority",
         "lucide-react"
       ],
-      "registryDependencies": ["utils", "spinner", "theme"],
+      "registryDependencies": [
+        "@nebari/utils",
+        "@nebari/spinner",
+        "@nebari/theme"
+      ],
       "files": [
         {
           "path": "registry/nebari/ui/button.tsx",
@@ -53,7 +57,7 @@
       "title": "Switch",
       "description": "Toggle a single setting on or off with immediate effect, built on Base UI's Switch.",
       "dependencies": ["@base-ui-components/react"],
-      "registryDependencies": ["utils", "theme"],
+      "registryDependencies": ["@nebari/utils", "@nebari/theme"],
       "files": [
         {
           "path": "registry/nebari/ui/switch.tsx",
@@ -71,7 +75,7 @@
         "class-variance-authority",
         "lucide-react"
       ],
-      "registryDependencies": ["utils", "theme"],
+      "registryDependencies": ["@nebari/utils", "@nebari/theme"],
       "files": [
         {
           "path": "registry/nebari/ui/checkbox.tsx",
@@ -85,7 +89,7 @@
       "title": "Radio Group",
       "description": "Mutually exclusive radio group with default and boxed item variants, stable selected targets, and group-level validation feedback.",
       "dependencies": ["@base-ui-components/react", "class-variance-authority"],
-      "registryDependencies": ["utils", "theme"],
+      "registryDependencies": ["@nebari/utils", "@nebari/theme"],
       "files": [
         {
           "path": "registry/nebari/ui/radio-group.tsx",
@@ -99,7 +103,7 @@
       "title": "Field",
       "description": "Groups a control with its label, description, and validation message, wiring accessible-name and description associations automatically. Built on Base UI's Field.",
       "dependencies": ["@base-ui-components/react"],
-      "registryDependencies": ["utils"],
+      "registryDependencies": ["@nebari/utils"],
       "files": [
         {
           "path": "registry/nebari/ui/field.tsx",
@@ -113,7 +117,7 @@
       "title": "Input",
       "description": "Single-line text-entry field with hover, focus, disabled, and invalid states, built on Base UI's Input and auto-wired to Field.",
       "dependencies": ["@base-ui-components/react", "lucide-react"],
-      "registryDependencies": ["utils", "theme"],
+      "registryDependencies": ["@nebari/utils", "@nebari/theme"],
       "files": [
         {
           "path": "registry/nebari/ui/input.tsx",
@@ -126,7 +130,7 @@
       "type": "registry:ui",
       "title": "Label",
       "description": "Accessible label for a form control, paired via htmlFor or composed with Field.",
-      "registryDependencies": ["utils"],
+      "registryDependencies": ["@nebari/utils"],
       "files": [
         {
           "path": "registry/nebari/ui/label.tsx",
@@ -140,7 +144,7 @@
       "title": "Textarea",
       "description": "Multi-line text-entry field — a styled native textarea mirroring Input's border, focus ring, disabled, and invalid states.",
       "dependencies": ["lucide-react"],
-      "registryDependencies": ["utils", "theme"],
+      "registryDependencies": ["@nebari/utils", "@nebari/theme"],
       "files": [
         {
           "path": "registry/nebari/ui/textarea.tsx",
@@ -153,7 +157,7 @@
       "type": "registry:ui",
       "title": "Table",
       "description": "Responsive data table with Nebari header, cell, row, footer, caption, and hover styling.",
-      "registryDependencies": ["utils", "theme"],
+      "registryDependencies": ["@nebari/utils", "@nebari/theme"],
       "files": [
         {
           "path": "registry/nebari/ui/table.tsx",
@@ -167,7 +171,7 @@
       "title": "Alert",
       "description": "Inline status message with default, success, warning, and destructive variants, composed of Alert, AlertTitle, AlertDescription, and AlertAction.",
       "dependencies": ["class-variance-authority", "lucide-react"],
-      "registryDependencies": ["utils"],
+      "registryDependencies": ["@nebari/utils"],
       "files": [
         {
           "path": "registry/nebari/ui/alert.tsx",
@@ -181,7 +185,7 @@
       "title": "Badge",
       "description": "Small status/label chip with variants, composable via Base UI's render prop.",
       "dependencies": ["@base-ui-components/react", "class-variance-authority"],
-      "registryDependencies": ["utils"],
+      "registryDependencies": ["@nebari/utils"],
       "files": [
         {
           "path": "registry/nebari/ui/badge.tsx",
@@ -195,7 +199,7 @@
       "title": "Card",
       "description": "Static content surface composed from header, title, description, action, content, and footer sections.",
       "dependencies": ["class-variance-authority"],
-      "registryDependencies": ["utils"],
+      "registryDependencies": ["@nebari/utils"],
       "files": [
         {
           "path": "registry/nebari/ui/card.tsx",
@@ -209,7 +213,11 @@
       "title": "Dialog",
       "description": "Modal dialog with overlay, close control, header, footer, title, and description parts, built on Base UI's Dialog.",
       "dependencies": ["@base-ui-components/react", "lucide-react"],
-      "registryDependencies": ["utils", "button", "theme"],
+      "registryDependencies": [
+        "@nebari/utils",
+        "@nebari/button",
+        "@nebari/theme"
+      ],
       "files": [
         {
           "path": "registry/nebari/ui/dialog.tsx",
@@ -223,7 +231,7 @@
       "title": "Tabs",
       "description": "Tabs for switching between related panels, with pill and underline variants built on Base UI.",
       "dependencies": ["@base-ui-components/react", "class-variance-authority"],
-      "registryDependencies": ["utils"],
+      "registryDependencies": ["@nebari/utils"],
       "files": [
         {
           "path": "registry/nebari/ui/tabs.tsx",
@@ -237,7 +245,7 @@
       "title": "Select",
       "description": "Accessible standard-size select menu with grouped labels, separators, validation states, and anchored popup positioning.",
       "dependencies": ["@base-ui-components/react", "lucide-react"],
-      "registryDependencies": ["utils", "theme"],
+      "registryDependencies": ["@nebari/utils", "@nebari/theme"],
       "files": [
         {
           "path": "registry/nebari/ui/select.tsx",


### PR DESCRIPTION
Namespace in-repo registryDependencies as @nebari/* Bare-name registry deps (e.g. "theme") made the shadcn CLI resolve them against the default registry's styles/<style>/theme.json on the consumer side — a 404 that aborted `npx shadcn add @nebari/<name>`. Reference in-repo items by their @nebari/<name> namespace instead, which resolves through the @nebari registry consumers already have configured.

Also update the AGENTS.md convention and the nebari-component skill so new components follow the namespaced form.

## Reference Issues or PRs

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create a link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

## What does this implement/fix?

_Put a `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [x] Did you test the pull request locally?
- [ ] Did you add new tests?

## Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Nebari Internals docs.
  - If no docs exist:
    - Create a stub for documentation, including bullet points for how to use the feature, code snippets (including from
      happy path tests), etc.
We want to ensure that the content produced for Nebari is accessible; if you are making significant contributions,
please address the access-centred guidelines in your content and complete our checklist. Thanks to @isabela-pf for this checklist :)
-->

### Access-centered content checklist

#### Text styling

- [ ] The content is written with [plain language](https://www.plainlanguage.gov/guidelines/) (where relevant).
- [ ] If there are headers, they use the proper header tags (with only one level-one header: `H1` or `#` in markdown).
- [ ] All links describe where they link to (for example, check the [Nebari website](https://nebari.dev/)).
- [ ] This content adheres to the Nebari style guides.

#### Non-text content

- [ ] All content is represented as text (for example, images need alt text, and videos need captions or descriptive transcripts).
- [ ] If there are emojis, there are not more than three in a row.
- [ ] Don't use [flashing GIFs or videos](https://www.w3.org/TR/UNDERSTANDING-WCAG20/seizure-does-not-violate.html).
- [ ] If the content were to be read as plain text, it still makes sense, and no information is missing.

## Any other comments?

<!--
Please be aware that we are a loose team of volunteers, so patience is necessary;
assistance handling other issues is very welcome.
We value all user contributions. If we are slow to review, either the pull request needs some benchmarking, tinkering,
convincing, etc., or the reviewers are likely busy. In either case,
we ask for your understanding during the
review process.
Thanks for contributing to Nebari 🙏🏼!
-->
