### PR TITLE
unify controls

### DIFF
--- a/.claude/skills/nebari-component/SKILL.md
+++ b/.claude/skills/nebari-component/SKILL.md
@@ -292,7 +292,62 @@ A component that references motion tokens (`--duration-*`, `--ease-*`,
 
 ## Step 3 — the story
 
-Create `stories/<name>.stories.tsx` (CSF3, one story per meaningful variant):
+Create `stories/<name>.stories.tsx` (CSF3, one story per meaningful variant).
+
+### Controls convention (required)
+
+`Default` is the interactive playground; every other story shows only the props
+it varies. Seven rules, applied by every story under `Components/*`:
+
+1. **Meta declares the full documented prop surface.** Each prop gets a
+   `description`, a `control`, `options` for unions, and `table.defaultValue`
+   when the component has a real default (omit it for props with none, like
+   `children` or `placeholder`). Consumer-facing props that cannot be
+   represented by a knob, especially Base UI's `render` prop, stay visible with
+   `control: false`.
+2. **Depth = own props + key state props.** The component's own props and cva
+   variant keys, plus the inherited Base UI/HTML props a playground needs
+   (`open`/`defaultOpen`, `checked`/`defaultChecked`, `disabled`, `placeholder`,
+   `aria-invalid`, …). Not the whole inherited surface.
+3. **Hide plumbing; document everything else.** Two distinct tools:
+   - `table: { disable: true }` — implementation plumbing and callbacks only:
+     `className`, `style`, `id`, `portalProps`, `viewportClassName`,
+     `overlayClassName`, `validate`, `onValueChange`, and props the component
+     hardcodes (e.g. tooltip's `role`).
+   - `control: false` plus a `description` — consumer APIs that cannot be a
+     knob: Base UI's `render`, `children` when the component is composed from
+     subcomponents (the knob would be meaningless JSX), and controlled-state
+     props (see rule 7). These stay visible in the props table because
+     consumers need them.
+
+   Never use either for per-story narrowing; that always uses
+   `controls.include`.
+4. **`Default` is the playground.** Name it exactly `Default` and give it no
+   prop-fixing per-story `args` (baseline meta `args` are fine) and no
+   `parameters.controls`. Its `render` must thread `args` into the component so
+   every interactive knob is live.
+5. **Every other story sets `parameters.controls.include`**, listing exactly the
+   interactive props it sets in its own `args` — `[]` when it has none. An arg
+   used only to choose generated source or a fixed styling fixture (for example,
+   a showcase's `variant`) may remain in `args` while being omitted from
+   controls; it must not change the story's fixed behavior.
+6. **Composite components use the story-args pattern.** When the knobs span
+   subcomponents (tabs' `variant` lives on `TabsList`, dialog's `defaultOpen` on
+   the root), declare a local `<Name>StoryArgs` type with those props plus any
+   story-only toggles, use `satisfies Meta<NameStoryArgs>`, and label each
+   synthetic knob "Story-only toggle" in its description. See
+   `stories/card.stories.tsx`, `stories/tabs.stories.tsx`.
+7. **No no-op knobs — mind mount-only and controlled props.** Storybook
+   re-renders into a cached React root on an args change; it never remounts. So
+   a mount-only prop (`defaultChecked`, `defaultValue`, `defaultOpen`) exposed
+   as a live control would silently do nothing. Keep the control and key the
+   component on that prop so the knob forces a remount:
+   `<Switch key={String(args.defaultChecked)} {...args} />`. Its controlled
+   counterpart (`checked`, `value`, `open`) gets `control: false` with a
+   "left as a docs-only row here so the playground stays interactive" note —
+   a live controlled knob with no state wiring freezes the component the moment
+   it is touched. Use `control: false`, not `table: { disable: true }`: these
+   are real consumer APIs and belong in the props table.
 
 ```tsx
 import type { Meta, StoryObj } from '@storybook/react-vite';
@@ -301,27 +356,71 @@ import { Button } from '@/ui/button';
 const meta = {
   title: 'Components/Button',
   component: Button,
-  parameters: { layout: 'centered' },
+  parameters: {
+    layout: 'centered',
+    docs: { description: { component: 'One paragraph on what it is and when to use it.' } },
+  },
   args: { children: 'Button' },
+  argTypes: {
+    variant: {
+      description: 'Visual style of the button. `link` uses the foreground text color and no fill.',
+      control: 'select',
+      options: ['default', 'destructive', 'outline', 'secondary', 'ghost', 'link'],
+      table: { defaultValue: { summary: 'default' } },
+    },
+    size: {
+      description: 'Height and padding preset. The `icon-*` sizes are square.',
+      control: 'select',
+      options: ['xs', 'sm', 'default', 'lg', 'icon-xs', 'icon-sm', 'icon', 'icon-lg'],
+      table: { defaultValue: { summary: 'default' } },
+    },
+    loading: {
+      description: 'Renders a `Spinner`, sets `aria-busy`, and disables the button.',
+      control: 'boolean',
+      table: { defaultValue: { summary: 'false' } },
+    },
+    children: { description: 'Button content.', control: 'text' },
+    render: {
+      description: 'Base UI render-prop composition for swapping the rendered element.',
+      control: false,
+      table: { defaultValue: { summary: '<button type="button" />' } },
+    },
+    className: { table: { disable: true } },
+  },
 } satisfies Meta<typeof Button>;
 
 export default meta;
 
 type Story = StoryObj<typeof meta>;
 
+// Playground: no own args, no controls param — every prop is a live control.
 export const Default: Story = {};
-export const Secondary: Story = { args: { variant: 'secondary' } };
-export const Outline: Story = { args: { variant: 'outline' } };
-export const Small: Story = { args: { size: 'sm' } };
+
+// Varies one prop through its own args → expose just that prop.
+export const Loading: Story = {
+  args: { loading: true },
+  parameters: { controls: { include: ['loading'] } },
+};
+
+// Pure showcase — the render hardcodes the grid, so no knobs at all.
+export const Variants: Story = {
+  parameters: { controls: { include: [] } },
+  render: (args) => (
+    <div className="flex flex-wrap items-center gap-3">
+      <Button {...args} variant="default">Default</Button>
+      <Button {...args} variant="secondary">Secondary</Button>
+      <Button {...args} variant="ghost">Ghost</Button>
+    </div>
+  ),
+};
 ```
 
-To preview dark mode, wrap a story in `<div className="dark bg-background p-8">`
-(see `stories/Welcome.stories.tsx`).
+To preview dark mode, wrap a story in `<div className="dark bg-background p-8">`.
 
 Where feasible, include a story that exercises the component's interactive or
-animated states — for example a `Playground` story with all props exposed via
-controls, or an `Interactive` story with a `play` function that focuses, hovers,
-or clicks the element. Vitest/jsdom has no layout engine and cannot assert CSS
+animated states — `Default` already covers the all-props-exposed case, so add an
+`Interactive` story with a `play` function that focuses, hovers, or clicks the
+element. Vitest/jsdom has no layout engine and cannot assert CSS
 transitions; Storybook stories are the right place to visually verify motion.
 Add a comment in the test file where CSS transition coverage is intentionally
 absent (e.g. `// CSS transitions are not testable in jsdom; animated states are

--- a/.claude/skills/nebari-component/SKILL.md
+++ b/.claude/skills/nebari-component/SKILL.md
@@ -297,7 +297,9 @@ Create `stories/<name>.stories.tsx` (CSF3, one story per meaningful variant).
 ### Controls convention (required)
 
 `Default` is the interactive playground; every other story shows only the props
-it varies. Seven rules, applied by every story under `Components/*`:
+that apply to it, and every control it shows is a populated widget from first
+paint. Eight rules, applied by every story under `Components/*`
+(`tests/story-controls.test.ts` enforces what is statically checkable):
 
 1. **Meta declares the full documented prop surface.** Each prop gets a
    `description`, a `control`, `options` for unions, and `table.defaultValue`
@@ -317,7 +319,7 @@ it varies. Seven rules, applied by every story under `Components/*`:
    - `control: false` plus a `description` — consumer APIs that cannot be a
      knob: Base UI's `render`, `children` when the component is composed from
      subcomponents (the knob would be meaningless JSX), and controlled-state
-     props (see rule 7). These stay visible in the props table because
+     props (see rule 8). These stay visible in the props table because
      consumers need them.
 
    Never use either for per-story narrowing; that always uses
@@ -326,18 +328,52 @@ it varies. Seven rules, applied by every story under `Components/*`:
    prop-fixing per-story `args` (baseline meta `args` are fine) and no
    `parameters.controls`. Its `render` must thread `args` into the component so
    every interactive knob is live.
-5. **Every other story sets `parameters.controls.include`**, listing exactly the
-   interactive props it sets in its own `args` — `[]` when it has none. An arg
-   used only to choose generated source or a fixed styling fixture (for example,
-   a showcase's `variant`) may remain in `args` while being omitted from
-   controls; it must not change the story's fixed behavior.
-6. **Composite components use the story-args pattern.** When the knobs span
+5. **Every knob is seeded in meta `args`.** Storybook's boolean, number, and
+   object controls render a click-to-reveal "Set …" button while their value is
+   `undefined`, so an unseeded knob costs a click before it can be used. Seed
+   every declared knob with the value that reproduces the component's default
+   rendering — `false` for booleans, the documented default for selects, the
+   effective default for numbers — so seeding never changes what the story looks
+   like. Seed in meta, not per story: rule 4 keeps `Default` free of own args.
+   Optional free-text knobs (`loadingText`, `htmlFor`) need no seed; a text
+   control always renders an input.
+
+   Where an unset prop is itself a meaningful state, model it as an explicit
+   `auto` option rather than leaving the arg undefined — a story-args union plus
+   a lookup back to the real value, the pattern dialog already uses for `modal`:
+
+   ```tsx
+   // stories/drawer.stories.tsx
+   const SWIPE_HANDLE_BY_KEY = { auto: undefined, shown: true, hidden: false } as const;
+   // argTypes: control 'inline-radio', options ['auto', 'shown', 'hidden']
+   // args: { showSwipeHandle: 'auto' }
+   ```
+
+   Without it the knob is both click-to-reveal *and* a one-way door: once
+   touched, there is no way back to the automatic behavior.
+6. **Every other story sets `parameters.controls.include` to the props that
+   apply to it.** Derive the list:
+   - Express the story's subject through its own `args` whenever it is one prop
+     on one instance (`args: { variant: 'underline' }`, not
+     `<ExampleTabs variant="underline" />`), so the subject is a live control.
+     Every prop a story pins in `args` must appear in its `include`.
+   - Thread `args` into the rendered component(s) and add the knobs that stay
+     live — typically the variant/size axes and state flags.
+   - Drop what the story fixes per instance (the axis a showcase grid
+     enumerates, the labels it supplies), what its composition makes inert
+     (`loadingText` at icon-only sizes, `size` where `className` overrides the
+     spacing it sets), and what would hide the point of the story (`disabled` on
+     a story about an open popup).
+   - `include: []` is correct only when nothing is left to adjust. Then the
+     render must not take `args` either — an args-consuming render with an empty
+     `include` is a dead panel. Say why in a comment.
+7. **Composite components use the story-args pattern.** When the knobs span
    subcomponents (tabs' `variant` lives on `TabsList`, dialog's `defaultOpen` on
    the root), declare a local `<Name>StoryArgs` type with those props plus any
    story-only toggles, use `satisfies Meta<NameStoryArgs>`, and label each
    synthetic knob "Story-only toggle" in its description. See
    `stories/card.stories.tsx`, `stories/tabs.stories.tsx`.
-7. **No no-op knobs — mind mount-only and controlled props.** Storybook
+8. **No no-op knobs — mind mount-only and controlled props.** Storybook
    re-renders into a cached React root on an args change; it never remounts. So
    a mount-only prop (`defaultChecked`, `defaultValue`, `defaultOpen`) exposed
    as a live control would silently do nothing. Keep the control and key the
@@ -360,7 +396,9 @@ const meta = {
     layout: 'centered',
     docs: { description: { component: 'One paragraph on what it is and when to use it.' } },
   },
-  args: { children: 'Button' },
+  // Every knob is seeded with the component's own default (rule 5), so no
+  // control opens as a "Set boolean" button.
+  args: { children: 'Button', disabled: false, loading: false, size: 'default', variant: 'default' },
   argTypes: {
     variant: {
       description: 'Visual style of the button. `link` uses the foreground text color and no fill.',
@@ -376,6 +414,11 @@ const meta = {
     },
     loading: {
       description: 'Renders a `Spinner`, sets `aria-busy`, and disables the button.',
+      control: 'boolean',
+      table: { defaultValue: { summary: 'false' } },
+    },
+    disabled: {
+      description: 'Disables the button and collapses it to the muted look.',
       control: 'boolean',
       table: { defaultValue: { summary: 'false' } },
     },
@@ -396,15 +439,17 @@ type Story = StoryObj<typeof meta>;
 // Playground: no own args, no controls param — every prop is a live control.
 export const Default: Story = {};
 
-// Varies one prop through its own args → expose just that prop.
+// Subject expressed through args, so `loading` stays live and can be toggled
+// off to compare against the resting state. Style axes come along.
 export const Loading: Story = {
   args: { loading: true },
-  parameters: { controls: { include: ['loading'] } },
+  parameters: { controls: { include: ['loading', 'variant', 'size'] } },
 };
 
-// Pure showcase — the render hardcodes the grid, so no knobs at all.
+// Showcase grid: it fixes `variant` and each label, so those drop out and the
+// remaining axes stay live.
 export const Variants: Story = {
-  parameters: { controls: { include: [] } },
+  parameters: { controls: { include: ['size', 'loading', 'disabled'] } },
   render: (args) => (
     <div className="flex flex-wrap items-center gap-3">
       <Button {...args} variant="default">Default</Button>
@@ -414,6 +459,10 @@ export const Variants: Story = {
   ),
 };
 ```
+
+For the `include: []` end of the spectrum — a story where nothing is left to
+adjust, so its render takes no args — see `Variants` in
+`stories/badge.stories.tsx` (every badge fixes both its variant and its label).
 
 To preview dark mode, wrap a story in `<div className="dark bg-background p-8">`.
 

--- a/.claude/skills/nebari-component/SKILL.md
+++ b/.claude/skills/nebari-component/SKILL.md
@@ -296,17 +296,19 @@ Create `stories/<name>.stories.tsx` (CSF3, one story per meaningful variant).
 
 ### Controls convention (required)
 
-`Default` is the interactive playground; every other story shows only the props
-that apply to it, and every control it shows is a populated widget from first
-paint. Eight rules, applied by every story under `Components/*`
+`Default` is the interactive playground and the only story with controls; every
+other story shows an empty panel unless it owns a knob outright, and every
+control `Default` shows is a populated widget from first paint. Eight rules,
+applied by every story under `Components/*`
 (`tests/story-controls.test.ts` enforces what is statically checkable):
 
 1. **Meta declares the full documented prop surface.** Each prop gets a
    `description`, a `control`, `options` for unions, and `table.defaultValue`
    when the component has a real default (omit it for props with none, like
-   `children` or `placeholder`). Consumer-facing props that cannot be
-   represented by a knob, especially Base UI's `render` prop, stay visible with
-   `control: false`.
+   `children` or `placeholder`). Unions always use `control: 'select'` — `radio`
+   and `inline-radio` are not used, whatever the option count. Consumer-facing
+   props that cannot be represented by a knob, especially Base UI's `render`
+   prop, stay visible with `control: false`.
 2. **Depth = own props + key state props.** The component's own props and cva
    variant keys, plus the inherited Base UI/HTML props a playground needs
    (`open`/`defaultOpen`, `checked`/`defaultChecked`, `disabled`, `placeholder`,
@@ -347,28 +349,24 @@ paint. Eight rules, applied by every story under `Components/*`
    ```tsx
    // stories/drawer.stories.tsx
    const SWIPE_HANDLE_BY_KEY = { auto: undefined, shown: true, hidden: false } as const;
-   // argTypes: control 'inline-radio', options ['auto', 'shown', 'hidden']
+   // argTypes: control 'select', options ['auto', 'shown', 'hidden']
    // args: { showSwipeHandle: 'auto' }
    ```
 
    Without it the knob is both click-to-reveal *and* a one-way door: once
    touched, there is no way back to the automatic behavior.
-6. **Every other story sets `parameters.controls.include` to the props that
-   apply to it.** Derive the list:
-   - Express the story's subject through its own `args` whenever it is one prop
+6. **Every other story sets `parameters.controls.include: []`.** The full prop
+   surface is adjustable in exactly one place — `Default` — and repeating a
+   slice of it under every story only invites the reader to knob a story out of
+   the state it exists to show.
+   - A story may list a prop in `include` only if it declares that prop in its
+     own per-story `argTypes` as a story-only knob. That is the one case where a
+     control belongs to a single story; see `CompleteNavbar` in
+     `stories/navigation-menu.stories.tsx`.
+   - The story's subject still goes through its own `args` when it is one prop
      on one instance (`args: { variant: 'underline' }`, not
-     `<ExampleTabs variant="underline" />`), so the subject is a live control.
-     Every prop a story pins in `args` must appear in its `include`.
-   - Thread `args` into the rendered component(s) and add the knobs that stay
-     live — typically the variant/size axes and state flags.
-   - Drop what the story fixes per instance (the axis a showcase grid
-     enumerates, the labels it supplies), what its composition makes inert
-     (`loadingText` at icon-only sizes, `size` where `className` overrides the
-     spacing it sets), and what would hide the point of the story (`disabled` on
-     a story about an open popup).
-   - `include: []` is correct only when nothing is left to adjust. Then the
-     render must not take `args` either — an args-consuming render with an empty
-     `include` is a dead panel. Say why in a comment.
+     `<ExampleTabs variant="underline" />`) — it is simply pinned rather than
+     live, and the render can keep threading `args`.
 7. **Composite components use the story-args pattern.** When the knobs span
    subcomponents (tabs' `variant` lives on `TabsList`, dialog's `defaultOpen` on
    the root), declare a local `<Name>StoryArgs` type with those props plus any
@@ -447,17 +445,17 @@ type Story = StoryObj<typeof meta>;
 // Playground: no own args, no controls param — every prop is a live control.
 export const Default: Story = {};
 
-// Subject expressed through args, so `loading` stays live and can be toggled
-// off to compare against the resting state. Style axes come along.
+// Subject pinned through args; the panel stays empty because `loading` is
+// already a live knob on `Default`.
 export const Loading: Story = {
   args: { loading: true },
-  parameters: { controls: { include: ['loading', 'variant', 'size'] } },
+  parameters: { controls: { include: [] } },
 };
 
-// Showcase grid: it fixes `variant` and each label, so those drop out and the
-// remaining axes stay live.
+// Showcase grid. It still threads `args` for the meta baseline, but nothing
+// here is adjustable.
 export const Variants: Story = {
-  parameters: { controls: { include: ['size', 'loading', 'disabled'] } },
+  parameters: { controls: { include: [] } },
   render: (args) => (
     <div className="flex flex-wrap items-center gap-3">
       <Button {...args} variant="default">Default</Button>
@@ -468,9 +466,8 @@ export const Variants: Story = {
 };
 ```
 
-For the `include: []` end of the spectrum — a story where nothing is left to
-adjust, so its render takes no args — see `Variants` in
-`stories/badge.stories.tsx` (every badge fixes both its variant and its label).
+For the one exception — a story that owns its knobs and so keeps a populated
+panel — see `CompleteNavbar` in `stories/navigation-menu.stories.tsx`.
 
 To preview dark mode, wrap a story in `<div className="dark bg-background p-8">`.
 

--- a/.claude/skills/nebari-component/SKILL.md
+++ b/.claude/skills/nebari-component/SKILL.md
@@ -330,11 +330,13 @@ paint. Eight rules, applied by every story under `Components/*`
    every interactive knob is live.
 5. **Every knob is seeded in meta `args`.** Storybook's boolean, number, and
    object controls render a click-to-reveal "Set …" button while their value is
-   `undefined`, so an unseeded knob costs a click before it can be used. Seed
-   every declared knob with the value that reproduces the component's default
-   rendering — `false` for booleans, the documented default for selects, the
-   effective default for numbers — so seeding never changes what the story looks
-   like. Seed in meta, not per story: rule 4 keeps `Default` free of own args.
+   `undefined`, so an unseeded knob costs a click before it can be used. Default
+   to seeding with the component's own default — `false` for booleans, the
+   documented default for selects, the effective default for numbers. Where that
+   would make a dull playground, seed the state the playground is better off
+   opening in instead (`defaultChecked: true` on checkbox and switch,
+   `defaultValue: 33` on slider) and let `table.defaultValue` carry the real
+   default. Seed in meta, not per story: rule 4 keeps `Default` free of own args.
    Optional free-text knobs (`loadingText`, `htmlFor`) need no seed; a text
    control always renders an input.
 
@@ -377,8 +379,14 @@ paint. Eight rules, applied by every story under `Components/*`
    re-renders into a cached React root on an args change; it never remounts. So
    a mount-only prop (`defaultChecked`, `defaultValue`, `defaultOpen`) exposed
    as a live control would silently do nothing. Keep the control and key the
-   component on that prop so the knob forces a remount:
-   `<Switch key={String(args.defaultChecked)} {...args} />`. Its controlled
+   story on that prop from a meta decorator, so every story in the file gets the
+   remount for free instead of repeating a `key` in each `render`:
+
+   ```tsx
+   decorators: [(Story, { args }) => <Story key={String(args.defaultChecked)} />],
+   ```
+
+   Its controlled
    counterpart (`checked`, `value`, `open`) gets `control: false` with a
    "left as a docs-only row here so the playground stays interactive" note —
    a live controlled knob with no state wiring freezes the component the moment

--- a/.claude/skills/nebari-component/SKILL.md
+++ b/.claude/skills/nebari-component/SKILL.md
@@ -359,10 +359,15 @@ applied by every story under `Components/*`
    surface is adjustable in exactly one place — `Default` — and repeating a
    slice of it under every story only invites the reader to knob a story out of
    the state it exists to show.
-   - A story may list a prop in `include` only if it declares that prop in its
-     own per-story `argTypes` as a story-only knob. That is the one case where a
-     control belongs to a single story; see `CompleteNavbar` in
-     `stories/navigation-menu.stories.tsx`.
+   - A control may live on at most one non-Default story, and only if it applies
+     to that story and to no other. In practice that means a story-only knob the
+     story declares in its own per-story `argTypes`; see `CompleteNavbar` in
+     `stories/navigation-menu.stories.tsx`. A prop that would be relevant to two
+     or more stories belongs to `Default` alone.
+   - **Every `render` must take an args parameter, `_args` if it ignores them.**
+     Storybook computes `__isArgsStory` as `render && render.length > 0` and
+     skips the `include` filter entirely when it is false, so an `() => …` render
+     silently shows the whole meta surface no matter what `include` says.
    - The story's subject still goes through its own `args` when it is one prop
      on one instance (`args: { variant: 'underline' }`, not
      `<ExampleTabs variant="underline" />`) — it is simply pinned rather than
@@ -402,8 +407,6 @@ const meta = {
     layout: 'centered',
     docs: { description: { component: 'One paragraph on what it is and when to use it.' } },
   },
-  // Every knob is seeded with the component's own default (rule 5), so no
-  // control opens as a "Set boolean" button.
   args: { children: 'Button', disabled: false, loading: false, size: 'default', variant: 'default' },
   argTypes: {
     variant: {
@@ -442,18 +445,13 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-// Playground: no own args, no controls param — every prop is a live control.
 export const Default: Story = {};
 
-// Subject pinned through args; the panel stays empty because `loading` is
-// already a live knob on `Default`.
 export const Loading: Story = {
   args: { loading: true },
   parameters: { controls: { include: [] } },
 };
 
-// Showcase grid. It still threads `args` for the meta baseline, but nothing
-// here is adjustable.
 export const Variants: Story = {
   parameters: { controls: { include: [] } },
   render: (args) => (

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,22 @@ rules that are easy to get wrong:
 - **Location &amp; naming.** Component at `registry/nebari/ui/<name>.tsx`
   (kebab-case). Story at `stories/<name>.stories.tsx` (CSF3), test at
   `tests/<name>.test.tsx` — both top-level, never co-located.
+- **Storybook controls.** `Default` is the interactive playground: define the
+  documented prop surface in meta `argTypes`, keep its knobs live, and do not
+  narrow its controls. Every other story uses `parameters.controls.include` to
+  expose only the props it intentionally varies (`[]` for a fixed showcase).
+  Variant args may remain as styling/source metadata without becoming behavior
+  controls. Document consumer APIs that cannot be a knob — Base UI's `render`,
+  `children` on a composed component, controlled-state props — with
+  `control: false` plus a description, so they stay in the props table. Reserve
+  `table: { disable: true }` for implementation plumbing and callbacks
+  (`className`, `style`, `id`, `portalProps`, `onValueChange`, …). Composite
+  stories use a local story-args type for
+  props and story-only toggles spanning multiple subcomponents. No knob may be a
+  no-op: args changes re-render without remounting, so key the component on any
+  mount-only prop (`defaultChecked`, `defaultValue`, `defaultOpen`) you expose,
+  and leave its controlled counterpart (`checked`, `value`, `open`) as a
+  docs-only row with `control: false`.
 - **Variants via `cva`.** Define `variants` + `defaultVariants` and export the
   `*Variants` function alongside the component. Type props with
   `VariantProps<typeof xVariants>`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,19 +83,25 @@ rules that are easy to get wrong:
   `tests/<name>.test.tsx` — both top-level, never co-located.
 - **Storybook controls.** `Default` is the interactive playground: define the
   documented prop surface in meta `argTypes`, keep its knobs live, and do not
-  narrow its controls. Every other story uses `parameters.controls.include` to
-  expose only the props it intentionally varies (`[]` for a fixed showcase).
-  Variant args may remain as styling/source metadata without becoming behavior
-  controls. Document consumer APIs that cannot be a knob — Base UI's `render`,
-  `children` on a composed component, controlled-state props — with
-  `control: false` plus a description, so they stay in the props table. Reserve
-  `table: { disable: true }` for implementation plumbing and callbacks
-  (`className`, `style`, `id`, `portalProps`, `onValueChange`, …). Composite
-  stories use a local story-args type for
-  props and story-only toggles spanning multiple subcomponents. No knob may be a
-  no-op: args changes re-render without remounting, so key the component on any
-  mount-only prop (`defaultChecked`, `defaultValue`, `defaultOpen`) you expose,
-  and leave its controlled counterpart (`checked`, `value`, `open`) as a
+  narrow its controls. Seed every knob in meta `args` with the value that
+  reproduces the component's default rendering — boolean, number, and object
+  controls render a click-to-reveal "Set …" button while their arg is
+  `undefined`; where an unset prop is itself meaningful, model it as an explicit
+  `auto` option mapped back to `undefined` (see drawer's `showSwipeHandle`).
+  Every other story sets `parameters.controls.include` to the props that apply to
+  it: express its subject through its own `args` rather than hardcoding it in the
+  render, add the knobs the render leaves live, and drop what it fixes per
+  instance or makes inert. `include: []` is for stories where nothing is
+  adjustable — those take no `args` in their render either. Document consumer
+  APIs that cannot be a knob — Base UI's `render`, `children` on a composed
+  component, controlled-state props — with `control: false` plus a description,
+  so they stay in the props table. Reserve `table: { disable: true }` for
+  implementation plumbing and callbacks (`className`, `style`, `id`,
+  `portalProps`, `onValueChange`, …). Composite stories use a local story-args
+  type for props and story-only toggles spanning multiple subcomponents. No knob
+  may be a no-op: args changes re-render without remounting, so key the component
+  on any mount-only prop (`defaultChecked`, `defaultValue`, `defaultOpen`) you
+  expose, and leave its controlled counterpart (`checked`, `value`, `open`) as a
   docs-only row with `control: false`.
 - **Variants via `cva`.** Define `variants` + `defaultVariants` and export the
   `*Variants` function alongside the component. Type props with

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,11 +83,13 @@ rules that are easy to get wrong:
   `tests/<name>.test.tsx` — both top-level, never co-located.
 - **Storybook controls.** `Default` is the interactive playground: define the
   documented prop surface in meta `argTypes`, keep its knobs live, and do not
-  narrow its controls. Seed every knob in meta `args` with the value that
-  reproduces the component's default rendering — boolean, number, and object
-  controls render a click-to-reveal "Set …" button while their arg is
-  `undefined`; where an unset prop is itself meaningful, model it as an explicit
-  `auto` option mapped back to `undefined` (see drawer's `showSwipeHandle`).
+  narrow its controls. Seed every knob in meta `args` — boolean, number, and
+  object controls render a click-to-reveal "Set …" button while their arg is
+  `undefined`. Seed the component's own default unless that makes a dull
+  playground, in which case seed the better opening state and let
+  `table.defaultValue` carry the real one; where an unset prop is itself
+  meaningful, model it as an explicit `auto` option mapped back to `undefined`
+  (see drawer's `showSwipeHandle`).
   Every other story sets `parameters.controls.include` to the props that apply to
   it: express its subject through its own `args` rather than hardcoding it in the
   render, add the knobs the render leaves live, and drop what it fixes per
@@ -99,10 +101,11 @@ rules that are easy to get wrong:
   implementation plumbing and callbacks (`className`, `style`, `id`,
   `portalProps`, `onValueChange`, …). Composite stories use a local story-args
   type for props and story-only toggles spanning multiple subcomponents. No knob
-  may be a no-op: args changes re-render without remounting, so key the component
-  on any mount-only prop (`defaultChecked`, `defaultValue`, `defaultOpen`) you
-  expose, and leave its controlled counterpart (`checked`, `value`, `open`) as a
-  docs-only row with `control: false`.
+  may be a no-op: args changes re-render without remounting, so key the story on
+  any mount-only prop (`defaultChecked`, `defaultValue`, `defaultOpen`) you
+  expose — via a meta decorator, not a `key` in every `render` — and leave its
+  controlled counterpart (`checked`, `value`, `open`) as a docs-only row with
+  `control: false`.
 - **Variants via `cva`.** Define `variants` + `defaultVariants` and export the
   `*Variants` function alongside the component. Type props with
   `VariantProps<typeof xVariants>`.

--- a/README.md
+++ b/README.md
@@ -135,12 +135,17 @@ registry source, so imports resolve the same way they do in tests and builds.
 
 Component stories follow a shared controls pattern. `Default` is the interactive
 playground and exposes the documented knobs; every other story narrows controls
-with `parameters.controls.include`, using `[]` for a fixed showcase. Variant
-args can supply styling or generated-source context without becoming behavioral
-controls. Consumer composition APIs such as Base UI's `render` prop remain
+with `parameters.controls.include` to the props that apply to it — its own
+subject plus whatever its render leaves live — and uses `[]` only where nothing
+is adjustable. Every knob is seeded in the meta `args` with the component's own
+default, so controls open as populated widgets rather than click-to-reveal "Set
+…" buttons; a prop whose unset state is meaningful gets an explicit `auto`
+option instead. Consumer composition APIs such as Base UI's `render` prop remain
 visible in the props table with `control: false`, while implementation plumbing
 is hidden. The full authoring recipe is in
-`.claude/skills/nebari-component/SKILL.md`.
+`.claude/skills/nebari-component/SKILL.md`, and
+`tests/story-controls.test.ts` enforces the parts that can be checked
+statically.
 
 The preview loads the Nebari theme tokens and webfonts, enables autodocs for
 every component, and includes a toolbar switcher for light and dark themes. The

--- a/README.md
+++ b/README.md
@@ -133,6 +133,15 @@ The dev server runs at <http://localhost:6006>. Stories live in the top-level
 `*.stories.tsx`. Storybook uses the same Tailwind v4 setup and `@/*` alias as the
 registry source, so imports resolve the same way they do in tests and builds.
 
+Component stories follow a shared controls pattern. `Default` is the interactive
+playground and exposes the documented knobs; every other story narrows controls
+with `parameters.controls.include`, using `[]` for a fixed showcase. Variant
+args can supply styling or generated-source context without becoming behavioral
+controls. Consumer composition APIs such as Base UI's `render` prop remain
+visible in the props table with `control: false`, while implementation plumbing
+is hidden. The full authoring recipe is in
+`.claude/skills/nebari-component/SKILL.md`.
+
 The preview loads the Nebari theme tokens and webfonts, enables autodocs for
 every component, and includes a toolbar switcher for light and dark themes. The
 custom toolbar is retained instead of adding a second addon switch: its `theme`

--- a/registry/nebari/ui/code-block.tsx
+++ b/registry/nebari/ui/code-block.tsx
@@ -2,10 +2,8 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { CheckIcon, CopyIcon } from 'lucide-react';
 import type * as React from 'react';
 import {
-  Children,
   createContext,
   Fragment,
-  isValidElement,
   useCallback,
   useContext,
   useState,
@@ -23,12 +21,6 @@ interface CodeBlockContextValue {
    * a narrow, header-less block.
    */
   hasFloatingCopyButton: boolean;
-  /**
-   * Whether the header renders the copy button in its trailing slot. One
-   * `showCopyButton` governs both placements, so the knob always controls the
-   * button the reader can actually see.
-   */
-  showHeaderCopyButton: boolean;
 }
 
 const CodeBlockContext = createContext<CodeBlockContextValue | null>(null);
@@ -47,11 +39,9 @@ type CodeBlockProps = React.ComponentProps<'div'> & {
   /** Render a non-selectable, aria-hidden line-number gutter in the body. */
   showLineNumbers?: boolean;
   /**
-   * Render the block's copy button. It sits at the end of the
-   * {@link CodeBlockHeader} when there is one, and floats over the top-right of
-   * the body otherwise, so a bare block still offers copy. Set to `false` to
-   * drop it entirely — or when placing a {@link CodeBlockCopyButton} yourself,
-   * so the block doesn't render a second one.
+   * Render a floating copy button in the top-right corner. On by default so a
+   * bare block still offers copy. Set to `false` when composing your own
+   * {@link CodeBlockCopyButton} inside a {@link CodeBlockHeader}, to avoid two.
    */
   showCopyButton?: boolean;
   /**
@@ -63,37 +53,11 @@ type CodeBlockProps = React.ComponentProps<'div'> & {
 };
 
 /**
- * Does this subtree contain a {@link CodeBlockHeader}? The root renders before
- * its children, so it cannot be told by the header — it inspects the children it
- * was handed. Fragments are searched too, so `<><Header /><Body /></>` counts;
- * a header hidden inside another component does not, which is why
- * {@link CodeBlockHeader} is documented as a direct child.
- */
-function includesHeader(children: React.ReactNode): boolean {
-  return Children.toArray(children).some((child) => {
-    if (!isValidElement(child)) {
-      return false;
-    }
-
-    if (child.type === CodeBlockHeader) {
-      return true;
-    }
-
-    return (
-      child.type === Fragment &&
-      includesHeader((child.props as { children?: React.ReactNode }).children)
-    );
-  });
-}
-
-/**
  * CodeBlock frames a formatted, monospaced snippet. It shares the snippet with
  * its descendants via context, so {@link CodeBlockBody} and
  * {@link CodeBlockCopyButton} read the text without it being re-threaded.
- * Compose it with an optional {@link CodeBlockHeader} (language/filename label)
- * and a {@link CodeBlockBody}; the copy button comes from `showCopyButton`,
- * which places it in the header when there is one and floats it over the body
- * otherwise.
+ * Compose it with an optional {@link CodeBlockHeader} (language/filename label),
+ * a {@link CodeBlockBody}, and a {@link CodeBlockCopyButton}.
  *
  * Syntax highlighting is intentionally out of scope — the body renders plain
  * monospaced text.
@@ -107,19 +71,9 @@ function CodeBlock({
   children,
   ...props
 }: CodeBlockProps) {
-  // A header bar is the natural home for the copy button, so the block only
-  // floats one over the body when there is no header to put it in. Either way
-  // there is exactly one, and `showCopyButton` controls it.
-  const showFloatingCopyButton = showCopyButton && !includesHeader(children);
-
   return (
     <CodeBlockContext.Provider
-      value={{
-        code,
-        showLineNumbers,
-        hasFloatingCopyButton: showFloatingCopyButton,
-        showHeaderCopyButton: showCopyButton,
-      }}
+      value={{ code, showLineNumbers, hasFloatingCopyButton: showCopyButton }}
     >
       <div
         data-slot="code-block"
@@ -143,7 +97,7 @@ function CodeBlock({
         )}
         {...props}
       >
-        {showFloatingCopyButton ? <CodeBlockCopyButton floating /> : null}
+        {showCopyButton ? <CodeBlockCopyButton floating /> : null}
         {children}
       </div>
     </CodeBlockContext.Provider>
@@ -151,18 +105,10 @@ function CodeBlock({
 }
 
 /**
- * Header bar for a {@link CodeBlock}, holding a language/filename label. It also
- * renders the block's {@link CodeBlockCopyButton} in its trailing slot unless the
- * root sets `showCopyButton={false}` — so the copy affordance follows the header
- * rather than floating over the code.
+ * Header bar for a {@link CodeBlock}, typically holding a language/filename
+ * label and a {@link CodeBlockCopyButton}.
  */
-function CodeBlockHeader({
-  className,
-  children,
-  ...props
-}: React.ComponentProps<'div'>) {
-  const { showHeaderCopyButton } = useCodeBlockContext('CodeBlockHeader');
-
+function CodeBlockHeader({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="code-block-header"
@@ -171,10 +117,7 @@ function CodeBlockHeader({
         className,
       )}
       {...props}
-    >
-      {children}
-      {showHeaderCopyButton ? <CodeBlockCopyButton /> : null}
-    </div>
+    />
   );
 }
 

--- a/registry/nebari/ui/code-block.tsx
+++ b/registry/nebari/ui/code-block.tsx
@@ -2,8 +2,10 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { CheckIcon, CopyIcon } from 'lucide-react';
 import type * as React from 'react';
 import {
+  Children,
   createContext,
   Fragment,
+  isValidElement,
   useCallback,
   useContext,
   useState,
@@ -21,6 +23,12 @@ interface CodeBlockContextValue {
    * a narrow, header-less block.
    */
   hasFloatingCopyButton: boolean;
+  /**
+   * Whether the header renders the copy button in its trailing slot. One
+   * `showCopyButton` governs both placements, so the knob always controls the
+   * button the reader can actually see.
+   */
+  showHeaderCopyButton: boolean;
 }
 
 const CodeBlockContext = createContext<CodeBlockContextValue | null>(null);
@@ -39,9 +47,11 @@ type CodeBlockProps = React.ComponentProps<'div'> & {
   /** Render a non-selectable, aria-hidden line-number gutter in the body. */
   showLineNumbers?: boolean;
   /**
-   * Render a floating copy button in the top-right corner. On by default so a
-   * bare block still offers copy. Set to `false` when composing your own
-   * {@link CodeBlockCopyButton} inside a {@link CodeBlockHeader}, to avoid two.
+   * Render the block's copy button. It sits at the end of the
+   * {@link CodeBlockHeader} when there is one, and floats over the top-right of
+   * the body otherwise, so a bare block still offers copy. Set to `false` to
+   * drop it entirely — or when placing a {@link CodeBlockCopyButton} yourself,
+   * so the block doesn't render a second one.
    */
   showCopyButton?: boolean;
   /**
@@ -53,11 +63,37 @@ type CodeBlockProps = React.ComponentProps<'div'> & {
 };
 
 /**
+ * Does this subtree contain a {@link CodeBlockHeader}? The root renders before
+ * its children, so it cannot be told by the header — it inspects the children it
+ * was handed. Fragments are searched too, so `<><Header /><Body /></>` counts;
+ * a header hidden inside another component does not, which is why
+ * {@link CodeBlockHeader} is documented as a direct child.
+ */
+function includesHeader(children: React.ReactNode): boolean {
+  return Children.toArray(children).some((child) => {
+    if (!isValidElement(child)) {
+      return false;
+    }
+
+    if (child.type === CodeBlockHeader) {
+      return true;
+    }
+
+    return (
+      child.type === Fragment &&
+      includesHeader((child.props as { children?: React.ReactNode }).children)
+    );
+  });
+}
+
+/**
  * CodeBlock frames a formatted, monospaced snippet. It shares the snippet with
  * its descendants via context, so {@link CodeBlockBody} and
  * {@link CodeBlockCopyButton} read the text without it being re-threaded.
- * Compose it with an optional {@link CodeBlockHeader} (language/filename label),
- * a {@link CodeBlockBody}, and a {@link CodeBlockCopyButton}.
+ * Compose it with an optional {@link CodeBlockHeader} (language/filename label)
+ * and a {@link CodeBlockBody}; the copy button comes from `showCopyButton`,
+ * which places it in the header when there is one and floats it over the body
+ * otherwise.
  *
  * Syntax highlighting is intentionally out of scope — the body renders plain
  * monospaced text.
@@ -71,9 +107,19 @@ function CodeBlock({
   children,
   ...props
 }: CodeBlockProps) {
+  // A header bar is the natural home for the copy button, so the block only
+  // floats one over the body when there is no header to put it in. Either way
+  // there is exactly one, and `showCopyButton` controls it.
+  const showFloatingCopyButton = showCopyButton && !includesHeader(children);
+
   return (
     <CodeBlockContext.Provider
-      value={{ code, showLineNumbers, hasFloatingCopyButton: showCopyButton }}
+      value={{
+        code,
+        showLineNumbers,
+        hasFloatingCopyButton: showFloatingCopyButton,
+        showHeaderCopyButton: showCopyButton,
+      }}
     >
       <div
         data-slot="code-block"
@@ -97,7 +143,7 @@ function CodeBlock({
         )}
         {...props}
       >
-        {showCopyButton ? <CodeBlockCopyButton floating /> : null}
+        {showFloatingCopyButton ? <CodeBlockCopyButton floating /> : null}
         {children}
       </div>
     </CodeBlockContext.Provider>
@@ -105,10 +151,18 @@ function CodeBlock({
 }
 
 /**
- * Header bar for a {@link CodeBlock}, typically holding a language/filename
- * label and a {@link CodeBlockCopyButton}.
+ * Header bar for a {@link CodeBlock}, holding a language/filename label. It also
+ * renders the block's {@link CodeBlockCopyButton} in its trailing slot unless the
+ * root sets `showCopyButton={false}` — so the copy affordance follows the header
+ * rather than floating over the code.
  */
-function CodeBlockHeader({ className, ...props }: React.ComponentProps<'div'>) {
+function CodeBlockHeader({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<'div'>) {
+  const { showHeaderCopyButton } = useCodeBlockContext('CodeBlockHeader');
+
   return (
     <div
       data-slot="code-block-header"
@@ -117,7 +171,10 @@ function CodeBlockHeader({ className, ...props }: React.ComponentProps<'div'>) {
         className,
       )}
       {...props}
-    />
+    >
+      {children}
+      {showHeaderCopyButton ? <CodeBlockCopyButton /> : null}
+    </div>
   );
 }
 

--- a/stories/alert.stories.tsx
+++ b/stories/alert.stories.tsx
@@ -72,7 +72,6 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
-  name: 'Default',
   parameters: {
     docs: {
       description: {
@@ -93,7 +92,6 @@ export const Default: Story = {
 };
 
 export const Variants: Story = {
-  name: 'Variants',
   parameters: {
     // Each alert fixes its own `variant`, so only `role` stays live here.
     controls: { include: ['role'] },
@@ -208,7 +206,6 @@ export const WithAction: Story = {
 };
 
 export const Dismissible: Story = {
-  name: 'Dismissible',
   args: { variant: 'success' },
   parameters: {
     controls: { include: ['variant', 'role'] },

--- a/stories/alert.stories.tsx
+++ b/stories/alert.stories.tsx
@@ -48,7 +48,7 @@ const meta = {
     role: {
       description:
         'ARIA live-region role. `auto` (the default) derives it from `variant` — `alert` (assertive) for `warning` and `destructive`, `status` (polite) otherwise — and an explicit role overrides that when the alert is rendered before the user acts.',
-      control: 'inline-radio',
+      control: 'select',
       options: ['auto', 'status', 'alert'],
       table: {
         type: { summary: "'status' | 'alert'" },
@@ -90,8 +90,7 @@ export const Default: Story = {
 
 export const Variants: Story = {
   parameters: {
-    // Each alert fixes its own `variant`, so only `role` stays live here.
-    controls: { include: ['role'] },
+    controls: { include: [] },
     docs: {
       description: {
         story:
@@ -138,7 +137,7 @@ export const Variants: Story = {
 export const TitleOnly: Story = {
   name: 'Title only',
   parameters: {
-    controls: { include: ['variant', 'role'] },
+    controls: { include: [] },
     docs: {
       description: {
         story:
@@ -157,7 +156,7 @@ export const TitleOnly: Story = {
 export const WithoutIcon: Story = {
   name: 'Without icon',
   parameters: {
-    controls: { include: ['variant', 'role'] },
+    controls: { include: [] },
     docs: {
       description: {
         story:
@@ -178,7 +177,7 @@ export const WithoutIcon: Story = {
 export const WithAction: Story = {
   name: 'With action',
   parameters: {
-    controls: { include: ['variant', 'role'] },
+    controls: { include: [] },
     docs: {
       description: {
         story:
@@ -205,7 +204,7 @@ export const WithAction: Story = {
 export const Dismissible: Story = {
   args: { variant: 'success' },
   parameters: {
-    controls: { include: ['variant', 'role'] },
+    controls: { include: [] },
     docs: {
       description: {
         story:

--- a/stories/alert.stories.tsx
+++ b/stories/alert.stories.tsx
@@ -14,10 +14,7 @@ type AlertStoryArgs = Omit<AlertProps, 'role'> & {
   role: 'auto' | 'status' | 'alert';
 };
 
-// An unset `role` is the meaningful default — the Alert derives it from
-// `variant` — so the knob models it as an explicit `auto` option. Leaving the
-// arg undefined instead would render a click-to-reveal control and give the
-// story no way back to the derived role.
+// `auto` keeps the derived-from-`variant` role reachable from the knob.
 const ALERT_ROLE_BY_KEY: Record<string, AlertProps['role']> = {
   auto: undefined,
   status: 'status',

--- a/stories/alert.stories.tsx
+++ b/stories/alert.stories.tsx
@@ -24,6 +24,19 @@ const meta = {
       options: ['default', 'success', 'warning', 'destructive'],
       table: { defaultValue: { summary: 'default' } },
     },
+    role: {
+      description:
+        'ARIA live-region role. Derived from `variant` — `alert` (assertive) for `warning` and `destructive`, `status` (polite) otherwise — and overridable when the alert is rendered before the user acts.',
+      control: 'select',
+      options: ['status', 'alert'],
+      table: { defaultValue: { summary: 'status | alert (by variant)' } },
+    },
+    children: {
+      description:
+        'Composed content — `AlertTitle` and `AlertDescription`, plus an optional `lucide-react` icon as the first child for the leading-icon layout, and `AlertAction` for a trailing action.',
+      control: false,
+    },
+    className: { table: { disable: true } },
   },
 } satisfies Meta<typeof Alert>;
 
@@ -55,6 +68,7 @@ export const Default: Story = {
 export const Variants: Story = {
   name: 'Variants',
   parameters: {
+    controls: { include: [] },
     docs: {
       description: {
         story:
@@ -101,6 +115,7 @@ export const Variants: Story = {
 export const TitleOnly: Story = {
   name: 'Title only',
   parameters: {
+    controls: { include: [] },
     docs: {
       description: {
         story:
@@ -119,6 +134,7 @@ export const TitleOnly: Story = {
 export const WithoutIcon: Story = {
   name: 'Without icon',
   parameters: {
+    controls: { include: [] },
     docs: {
       description: {
         story:
@@ -139,6 +155,7 @@ export const WithoutIcon: Story = {
 export const WithAction: Story = {
   name: 'With action',
   parameters: {
+    controls: { include: [] },
     docs: {
       description: {
         story:
@@ -165,6 +182,7 @@ export const WithAction: Story = {
 export const Dismissible: Story = {
   name: 'Dismissible',
   parameters: {
+    controls: { include: [] },
     docs: {
       description: {
         story:

--- a/stories/alert.stories.tsx
+++ b/stories/alert.stories.tsx
@@ -1,8 +1,28 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { CircleAlert, CircleCheck, Info, TriangleAlert, X } from 'lucide-react';
 import { useRef, useState } from 'react';
-import { Alert, AlertAction, AlertDescription, AlertTitle } from '@/ui/alert';
+import {
+  Alert,
+  AlertAction,
+  AlertDescription,
+  type AlertProps,
+  AlertTitle,
+} from '@/ui/alert';
 import { Button } from '@/ui/button';
+
+type AlertStoryArgs = Omit<AlertProps, 'role'> & {
+  role: 'auto' | 'status' | 'alert';
+};
+
+// An unset `role` is the meaningful default — the Alert derives it from
+// `variant` — so the knob models it as an explicit `auto` option. Leaving the
+// arg undefined instead would render a click-to-reveal control and give the
+// story no way back to the derived role.
+const ALERT_ROLE_BY_KEY: Record<string, AlertProps['role']> = {
+  auto: undefined,
+  status: 'status',
+  alert: 'alert',
+};
 
 const meta = {
   title: 'Components/Alert',
@@ -16,6 +36,10 @@ const meta = {
       },
     },
   },
+  args: {
+    role: 'auto',
+    variant: 'default',
+  },
   argTypes: {
     variant: {
       description:
@@ -26,10 +50,13 @@ const meta = {
     },
     role: {
       description:
-        'ARIA live-region role. Derived from `variant` — `alert` (assertive) for `warning` and `destructive`, `status` (polite) otherwise — and overridable when the alert is rendered before the user acts.',
-      control: 'select',
-      options: ['status', 'alert'],
-      table: { defaultValue: { summary: 'status | alert (by variant)' } },
+        'ARIA live-region role. `auto` (the default) derives it from `variant` — `alert` (assertive) for `warning` and `destructive`, `status` (polite) otherwise — and an explicit role overrides that when the alert is rendered before the user acts.',
+      control: 'inline-radio',
+      options: ['auto', 'status', 'alert'],
+      table: {
+        type: { summary: "'status' | 'alert'" },
+        defaultValue: { summary: 'auto (status | alert by variant)' },
+      },
     },
     children: {
       description:
@@ -38,7 +65,7 @@ const meta = {
     },
     className: { table: { disable: true } },
   },
-} satisfies Meta<typeof Alert>;
+} satisfies Meta<AlertStoryArgs>;
 
 export default meta;
 
@@ -54,8 +81,8 @@ export const Default: Story = {
       },
     },
   },
-  render: (args) => (
-    <Alert {...args}>
+  render: ({ role = 'auto', ...args }) => (
+    <Alert {...args} role={ALERT_ROLE_BY_KEY[role]}>
       <Info />
       <AlertTitle>New environment available</AlertTitle>
       <AlertDescription>
@@ -68,7 +95,8 @@ export const Default: Story = {
 export const Variants: Story = {
   name: 'Variants',
   parameters: {
-    controls: { include: [] },
+    // Each alert fixes its own `variant`, so only `role` stays live here.
+    controls: { include: ['role'] },
     docs: {
       description: {
         story:
@@ -76,23 +104,23 @@ export const Variants: Story = {
       },
     },
   },
-  render: () => (
+  render: ({ role = 'auto', ...args }) => (
     <div className="flex flex-col gap-4">
-      <Alert variant="default">
+      <Alert {...args} role={ALERT_ROLE_BY_KEY[role]} variant="default">
         <Info />
         <AlertTitle>New environment available</AlertTitle>
         <AlertDescription>
           nebari-default-env 2.4.1 has been deployed to your cluster.
         </AlertDescription>
       </Alert>
-      <Alert variant="success">
+      <Alert {...args} role={ALERT_ROLE_BY_KEY[role]} variant="success">
         <CircleCheck />
         <AlertTitle>Conda environment created</AlertTitle>
         <AlertDescription>
           Your environment is ready to use in a new notebook.
         </AlertDescription>
       </Alert>
-      <Alert variant="warning">
+      <Alert {...args} role={ALERT_ROLE_BY_KEY[role]} variant="warning">
         <TriangleAlert />
         <AlertTitle>Kernel restarted</AlertTitle>
         <AlertDescription>
@@ -100,7 +128,7 @@ export const Variants: Story = {
           cleared.
         </AlertDescription>
       </Alert>
-      <Alert variant="destructive">
+      <Alert {...args} role={ALERT_ROLE_BY_KEY[role]} variant="destructive">
         <CircleAlert />
         <AlertTitle>Scheduled maintenance</AlertTitle>
         <AlertDescription>
@@ -115,7 +143,7 @@ export const Variants: Story = {
 export const TitleOnly: Story = {
   name: 'Title only',
   parameters: {
-    controls: { include: [] },
+    controls: { include: ['variant', 'role'] },
     docs: {
       description: {
         story:
@@ -123,8 +151,8 @@ export const TitleOnly: Story = {
       },
     },
   },
-  render: () => (
-    <Alert>
+  render: ({ role = 'auto', ...args }) => (
+    <Alert {...args} role={ALERT_ROLE_BY_KEY[role]}>
       <CircleCheck />
       <AlertTitle>Conda environment created successfully</AlertTitle>
     </Alert>
@@ -134,7 +162,7 @@ export const TitleOnly: Story = {
 export const WithoutIcon: Story = {
   name: 'Without icon',
   parameters: {
-    controls: { include: [] },
+    controls: { include: ['variant', 'role'] },
     docs: {
       description: {
         story:
@@ -142,8 +170,8 @@ export const WithoutIcon: Story = {
       },
     },
   },
-  render: () => (
-    <Alert>
+  render: ({ role = 'auto', ...args }) => (
+    <Alert {...args} role={ALERT_ROLE_BY_KEY[role]}>
       <AlertTitle>JupyterHub 4.1 is now available</AlertTitle>
       <AlertDescription>
         Contact your administrator to schedule the upgrade.
@@ -155,7 +183,7 @@ export const WithoutIcon: Story = {
 export const WithAction: Story = {
   name: 'With action',
   parameters: {
-    controls: { include: [] },
+    controls: { include: ['variant', 'role'] },
     docs: {
       description: {
         story:
@@ -163,8 +191,8 @@ export const WithAction: Story = {
       },
     },
   },
-  render: () => (
-    <Alert>
+  render: ({ role = 'auto', ...args }) => (
+    <Alert {...args} role={ALERT_ROLE_BY_KEY[role]}>
       <Info />
       <AlertTitle>Your session will expire soon</AlertTitle>
       <AlertDescription>
@@ -181,8 +209,9 @@ export const WithAction: Story = {
 
 export const Dismissible: Story = {
   name: 'Dismissible',
+  args: { variant: 'success' },
   parameters: {
-    controls: { include: [] },
+    controls: { include: ['variant', 'role'] },
     docs: {
       description: {
         story:
@@ -190,7 +219,7 @@ export const Dismissible: Story = {
       },
     },
   },
-  render: () => {
+  render: ({ role = 'auto', ...args }) => {
     const [open, setOpen] = useState(true);
     const showButtonRef = useRef<HTMLButtonElement>(null);
     const dismissButtonRef = useRef<HTMLButtonElement>(null);
@@ -213,7 +242,7 @@ export const Dismissible: Story = {
     }
 
     return (
-      <Alert variant="success">
+      <Alert {...args} role={ALERT_ROLE_BY_KEY[role]}>
         <CircleCheck />
         <AlertTitle>Conda environment created</AlertTitle>
         <AlertDescription>

--- a/stories/badge.stories.tsx
+++ b/stories/badge.stories.tsx
@@ -61,7 +61,7 @@ export const Variants: Story = {
       },
     },
   },
-  render: () => (
+  render: (_args) => (
     <div className="flex flex-wrap items-center gap-3">
       <Badge variant="default">Default</Badge>
       <Badge variant="secondary">Secondary</Badge>
@@ -83,7 +83,7 @@ export const WithLeadingIcon: Story = {
       },
     },
   },
-  render: () => (
+  render: (_args) => (
     <div className="flex flex-wrap items-center gap-3">
       <Badge variant="outline">
         <Circle className="fill-current" />
@@ -112,7 +112,7 @@ export const WithTrailingIcon: Story = {
       },
     },
   },
-  render: () => (
+  render: (_args) => (
     <div className="flex flex-wrap items-center gap-3">
       <Badge variant="outline">
         Verified

--- a/stories/badge.stories.tsx
+++ b/stories/badge.stories.tsx
@@ -133,7 +133,7 @@ export const WithTrailingIcon: Story = {
 export const AsLink: Story = {
   name: 'Render as link',
   parameters: {
-    controls: { include: ['variant'] },
+    controls: { include: [] },
     docs: {
       description: {
         story:

--- a/stories/badge.stories.tsx
+++ b/stories/badge.stories.tsx
@@ -27,6 +27,13 @@ const meta = {
         'Badge content — text, and optionally a leading/trailing icon.',
       control: 'text',
     },
+    render: {
+      description:
+        'Base UI render-prop composition. Swap the default `<span>` for another element — e.g. `render={<a href="…" />}` — while keeping the badge\'s styling.',
+      control: false,
+      table: { defaultValue: { summary: '<span />' } },
+    },
+    className: { table: { disable: true } },
   },
 } satisfies Meta<typeof Badge>;
 
@@ -48,6 +55,7 @@ export const Default: Story = {
 export const Variants: Story = {
   name: 'Variants',
   parameters: {
+    controls: { include: [] },
     docs: {
       description: {
         story:
@@ -79,6 +87,7 @@ export const Variants: Story = {
 export const WithLeadingIcon: Story = {
   name: 'With leading icon',
   parameters: {
+    controls: { include: [] },
     docs: {
       description: {
         story:
@@ -107,6 +116,7 @@ export const WithLeadingIcon: Story = {
 export const WithTrailingIcon: Story = {
   name: 'With trailing icon',
   parameters: {
+    controls: { include: [] },
     docs: {
       description: {
         story:
@@ -135,6 +145,7 @@ export const WithTrailingIcon: Story = {
 export const AsLink: Story = {
   name: 'Render as link',
   parameters: {
+    controls: { include: [] },
     docs: {
       description: {
         story:

--- a/stories/badge.stories.tsx
+++ b/stories/badge.stories.tsx
@@ -53,8 +53,6 @@ export const Default: Story = {
 
 export const Variants: Story = {
   parameters: {
-    // Every badge fixes both its `variant` and its label, so no knob is live
-    // here — use `Default` to play with a single badge.
     controls: { include: [] },
     docs: {
       description: {
@@ -77,8 +75,6 @@ export const Variants: Story = {
 export const WithLeadingIcon: Story = {
   name: 'With leading icon',
   parameters: {
-    // Each badge fixes the `variant` that carries its status meaning, and its
-    // own label, so no knob is live here.
     controls: { include: [] },
     docs: {
       description: {
@@ -108,7 +104,6 @@ export const WithLeadingIcon: Story = {
 export const WithTrailingIcon: Story = {
   name: 'With trailing icon',
   parameters: {
-    // Each badge fixes its own `variant` and label, so no knob is live here.
     controls: { include: [] },
     docs: {
       description: {

--- a/stories/badge.stories.tsx
+++ b/stories/badge.stories.tsx
@@ -42,7 +42,6 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
-  name: 'Default',
   parameters: {
     docs: {
       description: {
@@ -53,7 +52,6 @@ export const Default: Story = {
 };
 
 export const Variants: Story = {
-  name: 'Variants',
   parameters: {
     // Every badge fixes both its `variant` and its label, so no knob is live
     // here — use `Default` to play with a single badge.

--- a/stories/badge.stories.tsx
+++ b/stories/badge.stories.tsx
@@ -14,7 +14,7 @@ const meta = {
       },
     },
   },
-  args: { children: 'Badge' },
+  args: { children: 'Badge', variant: 'default' },
   argTypes: {
     variant: {
       description: 'Visual style of the badge.',
@@ -55,6 +55,8 @@ export const Default: Story = {
 export const Variants: Story = {
   name: 'Variants',
   parameters: {
+    // Every badge fixes both its `variant` and its label, so no knob is live
+    // here — use `Default` to play with a single badge.
     controls: { include: [] },
     docs: {
       description: {
@@ -63,23 +65,13 @@ export const Variants: Story = {
       },
     },
   },
-  render: (args) => (
+  render: () => (
     <div className="flex flex-wrap items-center gap-3">
-      <Badge {...args} variant="default">
-        Default
-      </Badge>
-      <Badge {...args} variant="secondary">
-        Secondary
-      </Badge>
-      <Badge {...args} variant="destructive">
-        Destructive
-      </Badge>
-      <Badge {...args} variant="outline">
-        Outline
-      </Badge>
-      <Badge {...args} variant="ghost">
-        Ghost
-      </Badge>
+      <Badge variant="default">Default</Badge>
+      <Badge variant="secondary">Secondary</Badge>
+      <Badge variant="destructive">Destructive</Badge>
+      <Badge variant="outline">Outline</Badge>
+      <Badge variant="ghost">Ghost</Badge>
     </div>
   ),
 };
@@ -87,6 +79,8 @@ export const Variants: Story = {
 export const WithLeadingIcon: Story = {
   name: 'With leading icon',
   parameters: {
+    // Each badge fixes the `variant` that carries its status meaning, and its
+    // own label, so no knob is live here.
     controls: { include: [] },
     docs: {
       description: {
@@ -95,17 +89,17 @@ export const WithLeadingIcon: Story = {
       },
     },
   },
-  render: (args) => (
+  render: () => (
     <div className="flex flex-wrap items-center gap-3">
-      <Badge {...args} variant="outline">
+      <Badge variant="outline">
         <Circle className="fill-current" />
         Active
       </Badge>
-      <Badge {...args} variant="secondary">
+      <Badge variant="secondary">
         <Circle className="fill-current" />
         Pending
       </Badge>
-      <Badge {...args} variant="destructive">
+      <Badge variant="destructive">
         <Circle className="fill-current" />
         Error
       </Badge>
@@ -116,6 +110,7 @@ export const WithLeadingIcon: Story = {
 export const WithTrailingIcon: Story = {
   name: 'With trailing icon',
   parameters: {
+    // Each badge fixes its own `variant` and label, so no knob is live here.
     controls: { include: [] },
     docs: {
       description: {
@@ -124,17 +119,17 @@ export const WithTrailingIcon: Story = {
       },
     },
   },
-  render: (args) => (
+  render: () => (
     <div className="flex flex-wrap items-center gap-3">
-      <Badge {...args} variant="outline">
+      <Badge variant="outline">
         Verified
         <Check />
       </Badge>
-      <Badge {...args} variant="default">
+      <Badge variant="default">
         Trending
         <TrendingUp />
       </Badge>
-      <Badge {...args} variant="destructive">
+      <Badge variant="destructive">
         Alert
         <Bell />
       </Badge>
@@ -145,7 +140,7 @@ export const WithTrailingIcon: Story = {
 export const AsLink: Story = {
   name: 'Render as link',
   parameters: {
-    controls: { include: [] },
+    controls: { include: ['variant'] },
     docs: {
       description: {
         story:

--- a/stories/breadcrumb.stories.tsx
+++ b/stories/breadcrumb.stories.tsx
@@ -285,8 +285,6 @@ export const Default: Story = {
 
 export const Ellipsis: Story = {
   parameters: {
-    // Fixed composition with a pinned source snippet — the `variant` preview
-    // knob belongs to `Default`, so nothing is adjustable here.
     controls: { include: [] },
     docs: {
       description: {
@@ -307,7 +305,6 @@ export const Ellipsis: Story = {
 
 export const Dropdown: Story = {
   parameters: {
-    // Fixed composition with a pinned source snippet.
     controls: { include: [] },
     docs: {
       description: {
@@ -329,7 +326,6 @@ export const Dropdown: Story = {
 export const RenderAsLink: Story = {
   name: 'Render as link',
   parameters: {
-    // Fixed composition demonstrating `render` on each link.
     controls: { include: [] },
     docs: {
       description: {

--- a/stories/breadcrumb.stories.tsx
+++ b/stories/breadcrumb.stories.tsx
@@ -287,6 +287,8 @@ export const Default: Story = {
 export const Ellipsis: Story = {
   name: 'Ellipsis',
   parameters: {
+    // Fixed composition with a pinned source snippet — the `variant` preview
+    // knob belongs to `Default`, so nothing is adjustable here.
     controls: { include: [] },
     docs: {
       description: {
@@ -308,6 +310,7 @@ export const Ellipsis: Story = {
 export const Dropdown: Story = {
   name: 'Dropdown',
   parameters: {
+    // Fixed composition with a pinned source snippet.
     controls: { include: [] },
     docs: {
       description: {
@@ -329,6 +332,7 @@ export const Dropdown: Story = {
 export const RenderAsLink: Story = {
   name: 'Render as link',
   parameters: {
+    // Fixed composition demonstrating `render` on each link.
     controls: { include: [] },
     docs: {
       description: {

--- a/stories/breadcrumb.stories.tsx
+++ b/stories/breadcrumb.stories.tsx
@@ -257,7 +257,6 @@ async function verifyCollapsedMenu(
 }
 
 export const Default: Story = {
-  name: 'Default',
   parameters: {
     docs: {
       description: {
@@ -285,7 +284,6 @@ export const Default: Story = {
 };
 
 export const Ellipsis: Story = {
-  name: 'Ellipsis',
   parameters: {
     // Fixed composition with a pinned source snippet — the `variant` preview
     // knob belongs to `Default`, so nothing is adjustable here.
@@ -308,7 +306,6 @@ export const Ellipsis: Story = {
 };
 
 export const Dropdown: Story = {
-  name: 'Dropdown',
   parameters: {
     // Fixed composition with a pinned source snippet.
     controls: { include: [] },

--- a/stories/breadcrumb.stories.tsx
+++ b/stories/breadcrumb.stories.tsx
@@ -146,7 +146,11 @@ const meta = {
       options: ['default', 'ellipsis', 'dropdown'],
       table: { defaultValue: { summary: 'default' } },
     },
-    children: { table: { disable: true } },
+    children: {
+      description:
+        'Composed content — a `BreadcrumbList` of `BreadcrumbItem`s separated by `BreadcrumbSeparator`, ending in a `BreadcrumbPage` for the current route.',
+      control: false,
+    },
     className: { table: { disable: true } },
   },
 } satisfies Meta<BreadcrumbStoryArgs>;
@@ -254,11 +258,7 @@ async function verifyCollapsedMenu(
 
 export const Default: Story = {
   name: 'Default',
-  args: {
-    variant: 'default',
-  },
   parameters: {
-    controls: { include: ['variant'] },
     docs: {
       description: {
         story:
@@ -286,11 +286,8 @@ export const Default: Story = {
 
 export const Ellipsis: Story = {
   name: 'Ellipsis',
-  args: {
-    variant: 'ellipsis',
-  },
   parameters: {
-    controls: { disable: true },
+    controls: { include: [] },
     docs: {
       description: {
         story:
@@ -310,11 +307,8 @@ export const Ellipsis: Story = {
 
 export const Dropdown: Story = {
   name: 'Dropdown',
-  args: {
-    variant: 'dropdown',
-  },
   parameters: {
-    controls: { disable: true },
+    controls: { include: [] },
     docs: {
       description: {
         story:
@@ -335,7 +329,7 @@ export const Dropdown: Story = {
 export const RenderAsLink: Story = {
   name: 'Render as link',
   parameters: {
-    controls: { disable: true },
+    controls: { include: [] },
     docs: {
       description: {
         story:

--- a/stories/breadcrumb.stories.tsx
+++ b/stories/breadcrumb.stories.tsx
@@ -297,7 +297,7 @@ export const Ellipsis: Story = {
       },
     },
   },
-  render: () => <CollapsedBreadcrumb variant="ellipsis" />,
+  render: (_args) => <CollapsedBreadcrumb variant="ellipsis" />,
   play: async ({ canvasElement }) => {
     await verifyCollapsedMenu(canvasElement, 'Show more breadcrumbs');
   },
@@ -317,7 +317,7 @@ export const Dropdown: Story = {
       },
     },
   },
-  render: () => <CollapsedBreadcrumb variant="dropdown" />,
+  render: (_args) => <CollapsedBreadcrumb variant="dropdown" />,
   play: async ({ canvasElement }) => {
     await verifyCollapsedMenu(canvasElement, 'Breadcrumb');
   },
@@ -334,7 +334,7 @@ export const RenderAsLink: Story = {
       },
     },
   },
-  render: () => (
+  render: (_args) => (
     <Breadcrumb>
       <BreadcrumbList>
         <BreadcrumbItem>

--- a/stories/button.stories.tsx
+++ b/stories/button.stories.tsx
@@ -100,7 +100,6 @@ export const Default: Story = {
 
 export const Variants: Story = {
   parameters: {
-    // The grid fixes `variant` and each label; the remaining axes stay live.
     controls: { include: ['size', 'loading', 'disabled'] },
     docs: {
       description: {
@@ -194,7 +193,6 @@ export const IconSizes: Story = {
 export const WithIcon: Story = {
   name: 'With icon',
   parameters: {
-    // Each button fixes its own `variant` and label to show icon placement.
     controls: { include: ['size', 'loading', 'disabled'] },
     docs: {
       description: {
@@ -224,9 +222,7 @@ export const WithIcon: Story = {
 export const Loading: Story = {
   args: { loading: true },
   parameters: {
-    // `loading` is the subject and stays live — toggle it off to compare each
-    // button against its resting state. The last button fixes `size` to show
-    // the icon-only collapse, so `size` is not a knob here.
+    // The last button fixes `size` to show the icon-only collapse.
     controls: { include: ['loading', 'variant', 'disabled'] },
     docs: {
       description: {

--- a/stories/button.stories.tsx
+++ b/stories/button.stories.tsx
@@ -100,7 +100,7 @@ export const Default: Story = {
 
 export const Variants: Story = {
   parameters: {
-    controls: { include: ['size', 'loading', 'disabled'] },
+    controls: { include: [] },
     docs: {
       description: {
         story:
@@ -134,7 +134,7 @@ export const Variants: Story = {
 
 export const Sizes: Story = {
   parameters: {
-    controls: { include: ['variant', 'loading', 'disabled'] },
+    controls: { include: [] },
     docs: {
       description: {
         story:
@@ -164,7 +164,7 @@ export const IconSizes: Story = {
   name: 'Icon sizes',
   parameters: {
     // `loadingText` is ignored at icon-only sizes, so it is left out here.
-    controls: { include: ['variant', 'loading', 'disabled'] },
+    controls: { include: [] },
     docs: {
       description: {
         story:
@@ -193,7 +193,7 @@ export const IconSizes: Story = {
 export const WithIcon: Story = {
   name: 'With icon',
   parameters: {
-    controls: { include: ['size', 'loading', 'disabled'] },
+    controls: { include: [] },
     docs: {
       description: {
         story:
@@ -223,7 +223,7 @@ export const Loading: Story = {
   args: { loading: true },
   parameters: {
     // The last button fixes `size` to show the icon-only collapse.
-    controls: { include: ['loading', 'variant', 'disabled'] },
+    controls: { include: [] },
     docs: {
       description: {
         story:
@@ -253,7 +253,7 @@ export const Loading: Story = {
 
 export const Disabled: Story = {
   parameters: {
-    controls: { include: ['disabled', 'variant', 'size'] },
+    controls: { include: [] },
     docs: {
       description: {
         story:
@@ -267,7 +267,7 @@ export const Disabled: Story = {
 export const AsLink: Story = {
   name: 'Render as link',
   parameters: {
-    controls: { include: ['variant', 'size', 'disabled'] },
+    controls: { include: [] },
     docs: {
       description: {
         story:

--- a/stories/button.stories.tsx
+++ b/stories/button.stories.tsx
@@ -14,7 +14,13 @@ const meta = {
       },
     },
   },
-  args: { children: 'Button' },
+  args: {
+    children: 'Button',
+    disabled: false,
+    loading: false,
+    size: 'default',
+    variant: 'default',
+  },
   argTypes: {
     variant: {
       description:
@@ -96,7 +102,8 @@ export const Default: Story = {
 export const Variants: Story = {
   name: 'Variants',
   parameters: {
-    controls: { include: [] },
+    // The grid fixes `variant` and each label; the remaining axes stay live.
+    controls: { include: ['size', 'loading', 'disabled'] },
     docs: {
       description: {
         story:
@@ -131,7 +138,7 @@ export const Variants: Story = {
 export const Sizes: Story = {
   name: 'Sizes',
   parameters: {
-    controls: { include: [] },
+    controls: { include: ['variant', 'loading', 'disabled'] },
     docs: {
       description: {
         story:
@@ -160,7 +167,8 @@ export const Sizes: Story = {
 export const IconSizes: Story = {
   name: 'Icon sizes',
   parameters: {
-    controls: { include: [] },
+    // `loadingText` is ignored at icon-only sizes, so it is left out here.
+    controls: { include: ['variant', 'loading', 'disabled'] },
     docs: {
       description: {
         story:
@@ -189,7 +197,8 @@ export const IconSizes: Story = {
 export const WithIcon: Story = {
   name: 'With icon',
   parameters: {
-    controls: { include: [] },
+    // Each button fixes its own `variant` and label to show icon placement.
+    controls: { include: ['size', 'loading', 'disabled'] },
     docs: {
       description: {
         story:
@@ -199,7 +208,7 @@ export const WithIcon: Story = {
   },
   render: (args) => (
     <div className="flex flex-wrap items-center gap-3">
-      <Button {...args}>
+      <Button {...args} variant="default">
         <Plus />
         New project
       </Button>
@@ -217,8 +226,12 @@ export const WithIcon: Story = {
 
 export const Loading: Story = {
   name: 'Loading',
+  args: { loading: true },
   parameters: {
-    controls: { include: [] },
+    // `loading` is the subject and stays live — toggle it off to compare each
+    // button against its resting state. The last button fixes `size` to show
+    // the icon-only collapse, so `size` is not a knob here.
+    controls: { include: ['loading', 'variant', 'disabled'] },
     docs: {
       description: {
         story:
@@ -228,24 +241,18 @@ export const Loading: Story = {
   },
   render: (args) => (
     <div className="flex flex-wrap items-center gap-3">
-      <Button {...args} loading loadingText="Saving…">
+      <Button {...args} loadingText="Saving…">
         Save
       </Button>
-      <Button {...args} loading loadingText="Creating…">
+      <Button {...args} loadingText="Creating…">
         <Plus />
         New project
       </Button>
-      <Button {...args} loading loadingText="Saving…">
+      <Button {...args} loadingText="Saving…">
         <Plus />
         Save
       </Button>
-      <Button
-        {...args}
-        aria-label="Add"
-        loading
-        size="icon"
-        loadingText="Adding…"
-      >
+      <Button {...args} aria-label="Add" loadingText="Adding…" size="icon">
         <Plus />
       </Button>
     </div>
@@ -255,7 +262,7 @@ export const Loading: Story = {
 export const Disabled: Story = {
   name: 'Disabled',
   parameters: {
-    controls: { include: ['disabled'] },
+    controls: { include: ['disabled', 'variant', 'size'] },
     docs: {
       description: {
         story:
@@ -269,7 +276,7 @@ export const Disabled: Story = {
 export const AsLink: Story = {
   name: 'Render as link',
   parameters: {
-    controls: { include: [] },
+    controls: { include: ['variant', 'size', 'disabled'] },
     docs: {
       description: {
         story:

--- a/stories/button.stories.tsx
+++ b/stories/button.stories.tsx
@@ -68,6 +68,13 @@ const meta = {
         'Button content — text, and optionally a leading/trailing icon.',
       control: 'text',
     },
+    render: {
+      description:
+        'Base UI render-prop composition. Swap the default `<button type="button">` for another element — e.g. `render={<a href="…" />}` — while keeping the button\'s styling and slot attributes.',
+      control: false,
+      table: { defaultValue: { summary: '<button type="button" />' } },
+    },
+    className: { table: { disable: true } },
   },
 } satisfies Meta<typeof Button>;
 
@@ -89,6 +96,7 @@ export const Default: Story = {
 export const Variants: Story = {
   name: 'Variants',
   parameters: {
+    controls: { include: [] },
     docs: {
       description: {
         story:
@@ -123,6 +131,7 @@ export const Variants: Story = {
 export const Sizes: Story = {
   name: 'Sizes',
   parameters: {
+    controls: { include: [] },
     docs: {
       description: {
         story:
@@ -151,6 +160,7 @@ export const Sizes: Story = {
 export const IconSizes: Story = {
   name: 'Icon sizes',
   parameters: {
+    controls: { include: [] },
     docs: {
       description: {
         story:
@@ -179,6 +189,7 @@ export const IconSizes: Story = {
 export const WithIcon: Story = {
   name: 'With icon',
   parameters: {
+    controls: { include: [] },
     docs: {
       description: {
         story:
@@ -207,6 +218,7 @@ export const WithIcon: Story = {
 export const Loading: Story = {
   name: 'Loading',
   parameters: {
+    controls: { include: [] },
     docs: {
       description: {
         story:
@@ -243,6 +255,7 @@ export const Loading: Story = {
 export const Disabled: Story = {
   name: 'Disabled',
   parameters: {
+    controls: { include: ['disabled'] },
     docs: {
       description: {
         story:
@@ -256,6 +269,7 @@ export const Disabled: Story = {
 export const AsLink: Story = {
   name: 'Render as link',
   parameters: {
+    controls: { include: [] },
     docs: {
       description: {
         story:

--- a/stories/button.stories.tsx
+++ b/stories/button.stories.tsx
@@ -89,7 +89,6 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
-  name: 'Default',
   parameters: {
     docs: {
       description: {
@@ -100,7 +99,6 @@ export const Default: Story = {
 };
 
 export const Variants: Story = {
-  name: 'Variants',
   parameters: {
     // The grid fixes `variant` and each label; the remaining axes stay live.
     controls: { include: ['size', 'loading', 'disabled'] },
@@ -136,7 +134,6 @@ export const Variants: Story = {
 };
 
 export const Sizes: Story = {
-  name: 'Sizes',
   parameters: {
     controls: { include: ['variant', 'loading', 'disabled'] },
     docs: {
@@ -225,7 +222,6 @@ export const WithIcon: Story = {
 };
 
 export const Loading: Story = {
-  name: 'Loading',
   args: { loading: true },
   parameters: {
     // `loading` is the subject and stays live — toggle it off to compare each
@@ -260,7 +256,6 @@ export const Loading: Story = {
 };
 
 export const Disabled: Story = {
-  name: 'Disabled',
   parameters: {
     controls: { include: ['disabled', 'variant', 'size'] },
     docs: {

--- a/stories/card.stories.tsx
+++ b/stories/card.stories.tsx
@@ -169,7 +169,7 @@ export const Sizes: Story = {
 
 export const WithAction: Story = {
   name: 'With action',
-  parameters: { controls: { include: ['size'] } },
+  parameters: { controls: { include: [] } },
   render: ({ showFooter: _showFooter, showHeader: _showHeader, ...args }) => (
     <Card {...args} className={singleCardClassName}>
       <CardHeader>
@@ -203,7 +203,7 @@ export const WithAction: Story = {
 
 export const HeaderExamples: Story = {
   name: 'Header examples',
-  parameters: { controls: { include: ['size'] } },
+  parameters: { controls: { include: [] } },
   render: ({ showFooter: _showFooter, showHeader: _showHeader, ...args }) => (
     <div className={responsiveThreeCardGridClassName}>
       <Card {...args} className={rowCardClassName}>
@@ -237,7 +237,7 @@ export const HeaderExamples: Story = {
 
 export const FooterExamples: Story = {
   name: 'Footer examples',
-  parameters: { controls: { include: ['size'] } },
+  parameters: { controls: { include: [] } },
   render: ({ showFooter: _showFooter, showHeader: _showHeader, ...args }) => (
     <div className={responsiveThreeCardGridClassName}>
       <Card {...args} className={rowCardClassName}>
@@ -281,7 +281,6 @@ export const FooterExamples: Story = {
 
 export const CustomSpacing: Story = {
   name: 'Custom spacing',
-  // `className` overrides `--card-spacing`, so a `size` knob would be inert.
   parameters: { controls: { include: [] } },
   render: () => (
     <div className={responsiveThreeCardGridClassName}>
@@ -317,7 +316,7 @@ export const CustomSpacing: Story = {
 
 export const EdgeToEdgeContent: Story = {
   name: 'Edge-to-edge content',
-  parameters: { controls: { include: ['size'] } },
+  parameters: { controls: { include: [] } },
   render: ({ showFooter: _showFooter, showHeader: _showHeader, ...args }) => (
     <Card {...args} className={singleCardClassName}>
       <img

--- a/stories/card.stories.tsx
+++ b/stories/card.stories.tsx
@@ -55,7 +55,11 @@ const meta = {
       table: { defaultValue: { summary: 'true' } },
     },
     className: { table: { disable: true } },
-    children: { table: { disable: true } },
+    children: {
+      description:
+        'Composed content — `CardHeader` (with `CardTitle`, `CardDescription`, `CardAction`), `CardContent`, and `CardFooter`.',
+      control: false,
+    },
   },
 } satisfies Meta<CardStoryArgs>;
 
@@ -124,6 +128,7 @@ export const Default: Story = {
 
 export const Sizes: Story = {
   name: 'Size',
+  parameters: { controls: { include: [] } },
   render: () => (
     <div className={responsiveTwoCardGridClassName}>
       <Card className={rowCardClassName}>
@@ -164,6 +169,7 @@ export const Sizes: Story = {
 
 export const WithAction: Story = {
   name: 'With action',
+  parameters: { controls: { include: [] } },
   render: () => (
     <Card className={singleCardClassName}>
       <CardHeader>
@@ -197,6 +203,7 @@ export const WithAction: Story = {
 
 export const HeaderExamples: Story = {
   name: 'Header examples',
+  parameters: { controls: { include: [] } },
   render: () => (
     <div className={responsiveThreeCardGridClassName}>
       <Card className={rowCardClassName}>
@@ -230,6 +237,7 @@ export const HeaderExamples: Story = {
 
 export const FooterExamples: Story = {
   name: 'Footer examples',
+  parameters: { controls: { include: [] } },
   render: () => (
     <div className={responsiveThreeCardGridClassName}>
       <Card className={rowCardClassName}>
@@ -273,6 +281,7 @@ export const FooterExamples: Story = {
 
 export const CustomSpacing: Story = {
   name: 'Custom spacing',
+  parameters: { controls: { include: [] } },
   render: () => (
     <div className={responsiveThreeCardGridClassName}>
       {[
@@ -307,6 +316,7 @@ export const CustomSpacing: Story = {
 
 export const EdgeToEdgeContent: Story = {
   name: 'Edge-to-edge content',
+  parameters: { controls: { include: [] } },
   render: () => (
     <Card className={singleCardClassName}>
       <img

--- a/stories/card.stories.tsx
+++ b/stories/card.stories.tsx
@@ -129,7 +129,7 @@ export const Default: Story = {
 export const Sizes: Story = {
   name: 'Size',
   parameters: { controls: { include: [] } },
-  render: () => (
+  render: (_args) => (
     <div className={responsiveTwoCardGridClassName}>
       <Card className={rowCardClassName}>
         <CardHeader>
@@ -282,7 +282,7 @@ export const FooterExamples: Story = {
 export const CustomSpacing: Story = {
   name: 'Custom spacing',
   parameters: { controls: { include: [] } },
-  render: () => (
+  render: (_args) => (
     <div className={responsiveThreeCardGridClassName}>
       {[
         {

--- a/stories/card.stories.tsx
+++ b/stories/card.stories.tsx
@@ -128,7 +128,6 @@ export const Default: Story = {
 
 export const Sizes: Story = {
   name: 'Size',
-  // Each card fixes the `size` it demonstrates, so no knob is live here.
   parameters: { controls: { include: [] } },
   render: () => (
     <div className={responsiveTwoCardGridClassName}>
@@ -282,8 +281,7 @@ export const FooterExamples: Story = {
 
 export const CustomSpacing: Story = {
   name: 'Custom spacing',
-  // Each card overrides `--card-spacing` in `className`, which wins over the
-  // value `size` sets — so a `size` knob here would be inert.
+  // `className` overrides `--card-spacing`, so a `size` knob would be inert.
   parameters: { controls: { include: [] } },
   render: () => (
     <div className={responsiveThreeCardGridClassName}>

--- a/stories/card.stories.tsx
+++ b/stories/card.stories.tsx
@@ -128,6 +128,7 @@ export const Default: Story = {
 
 export const Sizes: Story = {
   name: 'Size',
+  // Each card fixes the `size` it demonstrates, so no knob is live here.
   parameters: { controls: { include: [] } },
   render: () => (
     <div className={responsiveTwoCardGridClassName}>
@@ -169,9 +170,9 @@ export const Sizes: Story = {
 
 export const WithAction: Story = {
   name: 'With action',
-  parameters: { controls: { include: [] } },
-  render: () => (
-    <Card className={singleCardClassName}>
+  parameters: { controls: { include: ['size'] } },
+  render: ({ showFooter: _showFooter, showHeader: _showHeader, ...args }) => (
+    <Card {...args} className={singleCardClassName}>
       <CardHeader>
         <CardTitle>Environment status</CardTitle>
         <CardDescription>nebari-default-env is ready.</CardDescription>
@@ -203,21 +204,21 @@ export const WithAction: Story = {
 
 export const HeaderExamples: Story = {
   name: 'Header examples',
-  parameters: { controls: { include: [] } },
-  render: () => (
+  parameters: { controls: { include: ['size'] } },
+  render: ({ showFooter: _showFooter, showHeader: _showHeader, ...args }) => (
     <div className={responsiveThreeCardGridClassName}>
-      <Card className={rowCardClassName}>
+      <Card {...args} className={rowCardClassName}>
         <CardHeader>
           <CardTitle>Title only</CardTitle>
         </CardHeader>
       </Card>
-      <Card className={rowCardClassName}>
+      <Card {...args} className={rowCardClassName}>
         <CardHeader>
           <CardTitle>With description</CardTitle>
           <CardDescription>Use supporting copy for context.</CardDescription>
         </CardHeader>
       </Card>
-      <Card className={rowCardClassName}>
+      <Card {...args} className={rowCardClassName}>
         <CardHeader className="border-b">
           <CardTitle>With action</CardTitle>
           <CardDescription>Action aligns to the top-right.</CardDescription>
@@ -237,10 +238,10 @@ export const HeaderExamples: Story = {
 
 export const FooterExamples: Story = {
   name: 'Footer examples',
-  parameters: { controls: { include: [] } },
-  render: () => (
+  parameters: { controls: { include: ['size'] } },
+  render: ({ showFooter: _showFooter, showHeader: _showHeader, ...args }) => (
     <div className={responsiveThreeCardGridClassName}>
-      <Card className={rowCardClassName}>
+      <Card {...args} className={rowCardClassName}>
         <CardHeader>
           <CardTitle>Single action</CardTitle>
           <CardDescription>Primary command aligned left.</CardDescription>
@@ -249,7 +250,7 @@ export const FooterExamples: Story = {
           <Button size="sm">Create</Button>
         </CardFooter>
       </Card>
-      <Card className={rowCardClassName}>
+      <Card {...args} className={rowCardClassName}>
         <CardHeader>
           <CardTitle>Action pair</CardTitle>
           <CardDescription>Cancel and confirm side by side.</CardDescription>
@@ -261,7 +262,7 @@ export const FooterExamples: Story = {
           <Button size="sm">Confirm</Button>
         </CardFooter>
       </Card>
-      <Card className={rowCardClassName}>
+      <Card {...args} className={rowCardClassName}>
         <CardHeader>
           <CardTitle>Separated footer</CardTitle>
           <CardDescription>
@@ -281,6 +282,8 @@ export const FooterExamples: Story = {
 
 export const CustomSpacing: Story = {
   name: 'Custom spacing',
+  // Each card overrides `--card-spacing` in `className`, which wins over the
+  // value `size` sets — so a `size` knob here would be inert.
   parameters: { controls: { include: [] } },
   render: () => (
     <div className={responsiveThreeCardGridClassName}>
@@ -316,9 +319,9 @@ export const CustomSpacing: Story = {
 
 export const EdgeToEdgeContent: Story = {
   name: 'Edge-to-edge content',
-  parameters: { controls: { include: [] } },
-  render: () => (
-    <Card className={singleCardClassName}>
+  parameters: { controls: { include: ['size'] } },
+  render: ({ showFooter: _showFooter, showHeader: _showHeader, ...args }) => (
+    <Card {...args} className={singleCardClassName}>
       <img
         alt=""
         className="aspect-video w-full bg-secondary object-cover"

--- a/stories/checkbox.stories.tsx
+++ b/stories/checkbox.stories.tsx
@@ -35,7 +35,7 @@ function InteractiveIndeterminateCheckbox({
   );
 }
 
-function InvalidCheckboxExample() {
+function InvalidCheckboxExample({ variant }: { variant: CheckboxVariant }) {
   const [checked, setChecked] = useState(false);
   const isInvalid = !checked;
 
@@ -48,6 +48,7 @@ function InvalidCheckboxExample() {
           setChecked(nextChecked);
         }}
         required
+        variant={variant}
       >
         I agree to the terms and conditions
       </Checkbox>
@@ -73,6 +74,10 @@ const meta = {
   args: {
     children: 'Enable automatic updates',
     defaultChecked: true,
+    disabled: false,
+    indeterminate: false,
+    required: false,
+    variant: 'default',
   },
   argTypes: {
     variant: {
@@ -156,12 +161,13 @@ export const Default: Story = {
  */
 export const WithDescription: Story = {
   name: 'With description',
-  parameters: { controls: { include: [] } },
-  render: () => (
+  args: { description: 'Run updates when a newer image is available.' },
+  parameters: {
+    controls: { include: ['description', 'variant', 'defaultChecked'] },
+  },
+  render: (args) => (
     <div className="w-72">
-      <Checkbox description="Run updates when a newer image is available.">
-        Enable automatic updates
-      </Checkbox>
+      <Checkbox key={String(args.defaultChecked)} {...args} />
     </div>
   ),
 };
@@ -171,14 +177,25 @@ export const WithDescription: Story = {
  * checkbox fields in a wrapping row.
  */
 export const Horizontal: Story = {
-  parameters: { controls: { include: [] } },
-  render: () => (
+  // Each checkbox owns its label and value; the layout and state knobs apply to
+  // the whole group.
+  parameters: { controls: { include: ['variant', 'disabled'] } },
+  render: ({ disabled, variant }) => (
     <CheckboxGroup aria-label="Workspace features" orientation="horizontal">
-      <Checkbox defaultChecked value="notebooks">
+      <Checkbox
+        defaultChecked
+        disabled={disabled}
+        value="notebooks"
+        variant={variant}
+      >
         Notebooks
       </Checkbox>
-      <Checkbox value="dashboards">Dashboards</Checkbox>
-      <Checkbox value="jobs">Jobs</Checkbox>
+      <Checkbox disabled={disabled} value="dashboards" variant={variant}>
+        Dashboards
+      </Checkbox>
+      <Checkbox disabled={disabled} value="jobs" variant={variant}>
+        Jobs
+      </Checkbox>
     </CheckboxGroup>
   ),
 };
@@ -188,13 +205,16 @@ export const Horizontal: Story = {
  * Reach for it when the choice needs more visual weight or descriptive copy.
  */
 export const Box: Story = {
-  parameters: { controls: { include: [] } },
-  render: () => (
+  args: {
+    description: 'Allow collaborators to duplicate this environment.',
+    variant: 'box',
+  },
+  parameters: {
+    controls: { include: ['variant', 'description', 'defaultChecked'] },
+  },
+  render: (args) => (
     <div className="w-80">
-      <Checkbox
-        description="Allow collaborators to duplicate this environment."
-        variant="box"
-      >
+      <Checkbox key={String(args.defaultChecked)} {...args}>
         Allow environment cloning
       </Checkbox>
     </div>
@@ -206,11 +226,14 @@ export const Box: Story = {
  * not accept interaction.
  */
 export const Disabled: Story = {
-  parameters: { controls: { include: [] } },
-  render: () => (
+  args: { disabled: true },
+  // Each checkbox fixes the variant and checked state it demonstrates; toggle
+  // `disabled` to compare them against their enabled look.
+  parameters: { controls: { include: ['disabled'] } },
+  render: ({ disabled }) => (
     <div className="flex w-80 flex-col gap-4">
-      <Checkbox disabled>Enable usage reporting</Checkbox>
-      <Checkbox defaultChecked disabled variant="box">
+      <Checkbox disabled={disabled}>Enable usage reporting</Checkbox>
+      <Checkbox defaultChecked disabled={disabled} variant="box">
         Required by your organization
       </Checkbox>
     </div>
@@ -223,8 +246,8 @@ export const Disabled: Story = {
  */
 export const WithField: Story = {
   name: 'With Field',
-  parameters: { controls: { include: [] } },
-  render: () => (
+  parameters: { controls: { include: ['variant', 'disabled'] } },
+  render: ({ disabled, variant }) => (
     <Field className="w-80">
       <FieldLabel id="notifications-label">Notifications</FieldLabel>
       <FieldDescription id="notifications-desc">
@@ -233,6 +256,8 @@ export const WithField: Story = {
       <Checkbox
         aria-describedby="notifications-desc"
         aria-labelledby="notifications-label"
+        disabled={disabled}
+        variant={variant}
       >
         Email me product updates
       </Checkbox>
@@ -246,8 +271,11 @@ export const WithField: Story = {
  * cue. The error clears as soon as the user checks the box.
  */
 export const Invalid: Story = {
-  parameters: { controls: { include: [] } },
-  render: () => <InvalidCheckboxExample />,
+  // The example owns `checked`/`required`, so `variant` is the one live knob.
+  parameters: { controls: { include: ['variant'] } },
+  render: ({ variant }) => (
+    <InvalidCheckboxExample variant={variant ?? 'default'} />
+  ),
 };
 
 /**
@@ -255,6 +283,8 @@ export const Invalid: Story = {
  * resolves it to a normal checked or unchecked state.
  */
 export const Indeterminate: Story = {
+  // Both variants are shown side by side and the example owns `checked` and
+  // `indeterminate`, so nothing is left to adjust.
   parameters: { controls: { include: [] } },
   render: () => (
     <div className="grid w-[38rem] grid-cols-2 items-start gap-6">

--- a/stories/checkbox.stories.tsx
+++ b/stories/checkbox.stories.tsx
@@ -83,7 +83,7 @@ const meta = {
     variant: {
       description:
         'Field layout. `default` is an inline checkbox; `box` turns the label and description into a bordered, fully clickable card.',
-      control: 'inline-radio',
+      control: 'select',
       options: ['default', 'box'],
       table: { defaultValue: { summary: 'default' } },
     },
@@ -165,7 +165,7 @@ export const WithDescription: Story = {
   name: 'With description',
   args: { description: 'Run updates when a newer image is available.' },
   parameters: {
-    controls: { include: ['description', 'variant', 'defaultChecked'] },
+    controls: { include: [] },
   },
   render: (args) => (
     <div className="w-72">
@@ -179,7 +179,7 @@ export const WithDescription: Story = {
  * checkbox fields in a wrapping row.
  */
 export const Horizontal: Story = {
-  parameters: { controls: { include: ['variant', 'disabled'] } },
+  parameters: { controls: { include: [] } },
   render: ({ disabled, variant }) => (
     <CheckboxGroup aria-label="Workspace features" orientation="horizontal">
       <Checkbox
@@ -210,7 +210,7 @@ export const Box: Story = {
     variant: 'box',
   },
   parameters: {
-    controls: { include: ['variant', 'description', 'defaultChecked'] },
+    controls: { include: [] },
   },
   render: (args) => (
     <div className="w-80">
@@ -225,7 +225,7 @@ export const Box: Story = {
  */
 export const Disabled: Story = {
   args: { disabled: true },
-  parameters: { controls: { include: ['disabled'] } },
+  parameters: { controls: { include: [] } },
   render: ({ disabled }) => (
     <div className="flex w-80 flex-col gap-4">
       <Checkbox disabled={disabled}>Enable usage reporting</Checkbox>
@@ -241,7 +241,7 @@ export const Disabled: Story = {
  * description separate from the checkbox's own inline label.
  */
 export const WithField: Story = {
-  parameters: { controls: { include: ['variant', 'disabled'] } },
+  parameters: { controls: { include: [] } },
   render: ({ disabled, variant }) => (
     <Field className="w-80">
       <FieldLabel id="notifications-label">Notifications</FieldLabel>
@@ -266,7 +266,7 @@ export const WithField: Story = {
  * cue. The error clears as soon as the user checks the box.
  */
 export const Invalid: Story = {
-  parameters: { controls: { include: ['variant'] } },
+  parameters: { controls: { include: [] } },
   render: ({ variant }) => (
     <InvalidCheckboxExample variant={variant ?? 'default'} />
   ),

--- a/stories/checkbox.stories.tsx
+++ b/stories/checkbox.stories.tsx
@@ -71,18 +71,64 @@ const meta = {
     },
   },
   args: {
-    children: 'Checkbox Text',
+    children: 'Enable automatic updates',
+    defaultChecked: true,
   },
   argTypes: {
     variant: {
-      control: 'select',
+      description:
+        'Field layout. `default` is an inline checkbox; `box` turns the label and description into a bordered, fully clickable card.',
+      control: 'inline-radio',
       options: ['default', 'box'],
       table: { defaultValue: { summary: 'default' } },
     },
-    defaultChecked: { control: 'boolean' },
-    disabled: { control: 'boolean' },
-    indeterminate: { control: 'boolean' },
-    description: { control: 'text' },
+    children: {
+      description: 'The visible and accessible checkbox label.',
+      control: 'text',
+    },
+    description: {
+      description:
+        "Supplementary text beneath the label, exposed as the checkbox's accessible description.",
+      control: 'text',
+    },
+    defaultChecked: {
+      description: 'Initial state when the checkbox is uncontrolled.',
+      control: 'boolean',
+      table: { defaultValue: { summary: 'false' } },
+    },
+    checked: {
+      description:
+        'Controlled state. Pair it with `onCheckedChange`; left as a docs-only row here so the playground stays interactive.',
+      control: false,
+    },
+    indeterminate: {
+      description:
+        'Renders the mixed state (a dash instead of a check) for a partially-selected group of children. Clicking resolves it to checked or unchecked.',
+      control: 'boolean',
+      table: { defaultValue: { summary: 'false' } },
+    },
+    disabled: {
+      description:
+        'Mutes the label and fills the control with `muted`; a checked or indeterminate box keeps a `muted-foreground` fill with a `background`-colored mark. Blocks pointer and keyboard interaction.',
+      control: 'boolean',
+      table: { defaultValue: { summary: 'false' } },
+    },
+    required: {
+      description:
+        'Marks the checkbox as required for Base UI `Field` validation — it must be checked to pass.',
+      control: 'boolean',
+      table: { defaultValue: { summary: 'false' } },
+    },
+    onCheckedChange: {
+      description: 'Called with the next checked state on every toggle.',
+      action: 'checked changed',
+      control: false,
+    },
+    render: {
+      description:
+        'Base UI render-prop composition. Swap the rendered element while preserving checkbox behavior, styling, and slot attributes.',
+      control: false,
+    },
   },
 } satisfies Meta<typeof Checkbox>;
 
@@ -95,9 +141,11 @@ type Story = StoryObj<typeof meta>;
  * are enough context for a single boolean choice.
  */
 export const Default: Story = {
-  render: () => (
+  // `defaultChecked` is read once on mount, so key the checkbox on it to
+  // remount when the control changes.
+  render: (args) => (
     <div className="w-72">
-      <Checkbox defaultChecked>Enable automatic updates</Checkbox>
+      <Checkbox key={String(args.defaultChecked)} {...args} />
     </div>
   ),
 };
@@ -108,6 +156,7 @@ export const Default: Story = {
  */
 export const WithDescription: Story = {
   name: 'With description',
+  parameters: { controls: { include: [] } },
   render: () => (
     <div className="w-72">
       <Checkbox description="Run updates when a newer image is available.">
@@ -122,6 +171,7 @@ export const WithDescription: Story = {
  * checkbox fields in a wrapping row.
  */
 export const Horizontal: Story = {
+  parameters: { controls: { include: [] } },
   render: () => (
     <CheckboxGroup aria-label="Workspace features" orientation="horizontal">
       <Checkbox defaultChecked value="notebooks">
@@ -138,6 +188,7 @@ export const Horizontal: Story = {
  * Reach for it when the choice needs more visual weight or descriptive copy.
  */
 export const Box: Story = {
+  parameters: { controls: { include: [] } },
   render: () => (
     <div className="w-80">
       <Checkbox
@@ -155,6 +206,7 @@ export const Box: Story = {
  * not accept interaction.
  */
 export const Disabled: Story = {
+  parameters: { controls: { include: [] } },
   render: () => (
     <div className="flex w-80 flex-col gap-4">
       <Checkbox disabled>Enable usage reporting</Checkbox>
@@ -171,6 +223,7 @@ export const Disabled: Story = {
  */
 export const WithField: Story = {
   name: 'With Field',
+  parameters: { controls: { include: [] } },
   render: () => (
     <Field className="w-80">
       <FieldLabel id="notifications-label">Notifications</FieldLabel>
@@ -193,6 +246,7 @@ export const WithField: Story = {
  * cue. The error clears as soon as the user checks the box.
  */
 export const Invalid: Story = {
+  parameters: { controls: { include: [] } },
   render: () => <InvalidCheckboxExample />,
 };
 
@@ -201,6 +255,7 @@ export const Invalid: Story = {
  * resolves it to a normal checked or unchecked state.
  */
 export const Indeterminate: Story = {
+  parameters: { controls: { include: [] } },
   render: () => (
     <div className="grid w-[38rem] grid-cols-2 items-start gap-6">
       {variantRows.map((row) => (

--- a/stories/checkbox.stories.tsx
+++ b/stories/checkbox.stories.tsx
@@ -136,8 +136,7 @@ const meta = {
     },
   },
   decorators: [
-    // `defaultChecked` is read once on mount, so key the story on it to remount
-    // when the control changes — otherwise the knob would silently do nothing.
+    // `defaultChecked` is mount-only, so the key forces a remount when it changes.
     (Story, { args }) => <Story key={String(args.defaultChecked)} />,
   ],
 } satisfies Meta<typeof Checkbox>;
@@ -180,8 +179,6 @@ export const WithDescription: Story = {
  * checkbox fields in a wrapping row.
  */
 export const Horizontal: Story = {
-  // Each checkbox owns its label and value; the layout and state knobs apply to
-  // the whole group.
   parameters: { controls: { include: ['variant', 'disabled'] } },
   render: ({ disabled, variant }) => (
     <CheckboxGroup aria-label="Workspace features" orientation="horizontal">
@@ -228,8 +225,6 @@ export const Box: Story = {
  */
 export const Disabled: Story = {
   args: { disabled: true },
-  // Each checkbox fixes the variant and checked state it demonstrates; toggle
-  // `disabled` to compare them against their enabled look.
   parameters: { controls: { include: ['disabled'] } },
   render: ({ disabled }) => (
     <div className="flex w-80 flex-col gap-4">
@@ -271,7 +266,6 @@ export const WithField: Story = {
  * cue. The error clears as soon as the user checks the box.
  */
 export const Invalid: Story = {
-  // The example owns `checked`/`required`, so `variant` is the one live knob.
   parameters: { controls: { include: ['variant'] } },
   render: ({ variant }) => (
     <InvalidCheckboxExample variant={variant ?? 'default'} />
@@ -283,8 +277,6 @@ export const Invalid: Story = {
  * resolves it to a normal checked or unchecked state.
  */
 export const Indeterminate: Story = {
-  // Both variants are shown side by side and the example owns `checked` and
-  // `indeterminate`, so nothing is left to adjust.
   parameters: { controls: { include: [] } },
   render: () => (
     <div className="grid w-[38rem] grid-cols-2 items-start gap-6">

--- a/stories/checkbox.stories.tsx
+++ b/stories/checkbox.stories.tsx
@@ -135,6 +135,11 @@ const meta = {
       control: false,
     },
   },
+  decorators: [
+    // `defaultChecked` is read once on mount, so key the story on it to remount
+    // when the control changes — otherwise the knob would silently do nothing.
+    (Story, { args }) => <Story key={String(args.defaultChecked)} />,
+  ],
 } satisfies Meta<typeof Checkbox>;
 
 export default meta;
@@ -146,11 +151,9 @@ type Story = StoryObj<typeof meta>;
  * are enough context for a single boolean choice.
  */
 export const Default: Story = {
-  // `defaultChecked` is read once on mount, so key the checkbox on it to
-  // remount when the control changes.
   render: (args) => (
     <div className="w-72">
-      <Checkbox key={String(args.defaultChecked)} {...args} />
+      <Checkbox {...args} />
     </div>
   ),
 };
@@ -167,7 +170,7 @@ export const WithDescription: Story = {
   },
   render: (args) => (
     <div className="w-72">
-      <Checkbox key={String(args.defaultChecked)} {...args} />
+      <Checkbox {...args} />
     </div>
   ),
 };
@@ -214,9 +217,7 @@ export const Box: Story = {
   },
   render: (args) => (
     <div className="w-80">
-      <Checkbox key={String(args.defaultChecked)} {...args}>
-        Allow environment cloning
-      </Checkbox>
+      <Checkbox {...args}>Allow environment cloning</Checkbox>
     </div>
   ),
 };
@@ -245,7 +246,6 @@ export const Disabled: Story = {
  * description separate from the checkbox's own inline label.
  */
 export const WithField: Story = {
-  name: 'With Field',
   parameters: { controls: { include: ['variant', 'disabled'] } },
   render: ({ disabled, variant }) => (
     <Field className="w-80">

--- a/stories/checkbox.stories.tsx
+++ b/stories/checkbox.stories.tsx
@@ -278,7 +278,7 @@ export const Invalid: Story = {
  */
 export const Indeterminate: Story = {
   parameters: { controls: { include: [] } },
-  render: () => (
+  render: (_args) => (
     <div className="grid w-[38rem] grid-cols-2 items-start gap-6">
       {variantRows.map((row) => (
         <div className="space-y-3" key={row.label}>

--- a/stories/code-block.stories.tsx
+++ b/stories/code-block.stories.tsx
@@ -1,5 +1,10 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { CodeBlock, CodeBlockBody, CodeBlockHeader } from '@/ui/code-block';
+import {
+  CodeBlock,
+  CodeBlockBody,
+  CodeBlockCopyButton,
+  CodeBlockHeader,
+} from '@/ui/code-block';
 
 const basicSnippet = `pnpm dlx shadcn@latest add @nebari/code-block`;
 
@@ -51,7 +56,7 @@ const meta = {
     },
     showCopyButton: {
       description:
-        "Render the block's copy button. It sits at the end of the `CodeBlockHeader` when there is one, and floats over the top-right of the body otherwise.",
+        'Render a floating copy button in the top-right — for header-less blocks. Set it to `false` when composing your own `CodeBlockCopyButton` inside a `CodeBlockHeader`, so the block does not end up with two.',
       control: 'boolean',
       table: { defaultValue: { summary: 'true' } },
     },
@@ -85,14 +90,23 @@ export const Default: Story = {
   ),
 };
 
-/** Every knob is live in every story; only the fixed content differs. */
-const codeBlockControls = ['code', 'showLineNumbers', 'showCopyButton', 'dark'];
+/**
+ * `showCopyButton` governs the *floating* copy button on the root. Any story
+ * whose header composes its own `CodeBlockCopyButton` fixes it to `false` in the
+ * render — leaving it as a knob would offer to add a second, floating button
+ * rather than to hide the one on screen.
+ */
+const composedCopyButtonControls = ['code', 'showLineNumbers', 'dark'];
 
 export const HorizontalScroll: Story = {
   name: 'Horizontal scroll',
   args: { code: longLineSnippet },
   parameters: {
-    controls: { include: codeBlockControls },
+    // Header-less, so the floating copy button is the one on screen and its
+    // knob is live.
+    controls: {
+      include: ['code', 'showCopyButton', 'showLineNumbers', 'dark'],
+    },
     docs: {
       description: {
         story:
@@ -108,14 +122,9 @@ export const HorizontalScroll: Story = {
 };
 
 export const WithHeader: Story = {
-  args: {
-    showCopyButton: false
-  },
-
   name: 'With header',
-
   parameters: {
-    controls: { include: codeBlockControls },
+    controls: { include: composedCopyButtonControls },
     docs: {
       description: {
         story:
@@ -125,13 +134,14 @@ export const WithHeader: Story = {
   },
 
   render: (args) => (
-    <CodeBlock {...args} className="min-w-[28rem]">
+    <CodeBlock {...args} className="min-w-[28rem]" showCopyButton={false}>
       <CodeBlockHeader>
         <span>Terminal</span>
+        <CodeBlockCopyButton />
       </CodeBlockHeader>
       <CodeBlockBody />
     </CodeBlock>
-  )
+  ),
 };
 
 export const WithLineNumbers: Story = {
@@ -141,7 +151,7 @@ export const WithLineNumbers: Story = {
     showLineNumbers: true,
   },
   parameters: {
-    controls: { include: codeBlockControls },
+    controls: { include: composedCopyButtonControls },
     docs: {
       description: {
         story:
@@ -150,9 +160,10 @@ export const WithLineNumbers: Story = {
     },
   },
   render: (args) => (
-    <CodeBlock {...args}>
+    <CodeBlock {...args} showCopyButton={false}>
       <CodeBlockHeader>
         <span>example.tsx</span>
+        <CodeBlockCopyButton />
       </CodeBlockHeader>
       <CodeBlockBody />
     </CodeBlock>
@@ -166,7 +177,7 @@ export const MaxLines: Story = {
     showLineNumbers: false,
   },
   parameters: {
-    controls: { include: codeBlockControls },
+    controls: { include: composedCopyButtonControls },
     docs: {
       description: {
         story:
@@ -175,9 +186,10 @@ export const MaxLines: Story = {
     },
   },
   render: (args) => (
-    <CodeBlock {...args}>
+    <CodeBlock {...args} showCopyButton={false}>
       <CodeBlockHeader>
         <span>steps.ts — 24 lines, capped at 8</span>
+        <CodeBlockCopyButton />
       </CodeBlockHeader>
       <CodeBlockBody maxLines={8} />
     </CodeBlock>
@@ -192,7 +204,7 @@ export const Dark: Story = {
     dark: true,
   },
   parameters: {
-    controls: { include: codeBlockControls },
+    controls: { include: composedCopyButtonControls },
     docs: {
       description: {
         story:
@@ -201,9 +213,10 @@ export const Dark: Story = {
     },
   },
   render: (args) => (
-    <CodeBlock {...args}>
+    <CodeBlock {...args} showCopyButton={false}>
       <CodeBlockHeader>
         <span>example.tsx</span>
+        <CodeBlockCopyButton />
       </CodeBlockHeader>
       <CodeBlockBody />
     </CodeBlock>

--- a/stories/code-block.stories.tsx
+++ b/stories/code-block.stories.tsx
@@ -95,16 +95,13 @@ export const Default: Story = {
   ),
 };
 
-/** Excludes `showCopyButton`: it adds a second, floating button, not hides one. */
-const composedCopyButtonControls = ['code', 'showLineNumbers', 'dark'];
-
 export const HorizontalScroll: Story = {
   name: 'Horizontal scroll',
   args: { code: longLineSnippet },
   parameters: {
     // Header-less, so the floating copy button is the one on screen.
     controls: {
-      include: ['code', 'showCopyButton', 'showLineNumbers', 'dark'],
+      include: [],
     },
     docs: {
       description: {
@@ -123,7 +120,7 @@ export const HorizontalScroll: Story = {
 export const WithHeader: Story = {
   name: 'With header',
   parameters: {
-    controls: { include: composedCopyButtonControls },
+    controls: { include: [] },
     docs: {
       description: {
         story:
@@ -150,7 +147,7 @@ export const WithLineNumbers: Story = {
     showLineNumbers: true,
   },
   parameters: {
-    controls: { include: composedCopyButtonControls },
+    controls: { include: [] },
     docs: {
       description: {
         story:
@@ -176,7 +173,7 @@ export const MaxLines: Story = {
     showLineNumbers: false,
   },
   parameters: {
-    controls: { include: composedCopyButtonControls },
+    controls: { include: [] },
     docs: {
       description: {
         story:
@@ -202,7 +199,7 @@ export const Dark: Story = {
     dark: true,
   },
   parameters: {
-    controls: { include: composedCopyButtonControls },
+    controls: { include: [] },
     docs: {
       description: {
         story:

--- a/stories/code-block.stories.tsx
+++ b/stories/code-block.stories.tsx
@@ -1,10 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import {
-  CodeBlock,
-  CodeBlockBody,
-  CodeBlockCopyButton,
-  CodeBlockHeader,
-} from '@/ui/code-block';
+import { CodeBlock, CodeBlockBody, CodeBlockHeader } from '@/ui/code-block';
 
 const basicSnippet = `pnpm dlx shadcn@latest add @nebari/code-block`;
 
@@ -56,7 +51,7 @@ const meta = {
     },
     showCopyButton: {
       description:
-        'Render a floating copy button in the top-right — for header-less blocks.',
+        "Render the block's copy button. It sits at the end of the `CodeBlockHeader` when there is one, and floats over the top-right of the body otherwise.",
       control: 'boolean',
       table: { defaultValue: { summary: 'true' } },
     },
@@ -90,11 +85,14 @@ export const Default: Story = {
   ),
 };
 
+/** Every knob is live in every story; only the fixed content differs. */
+const codeBlockControls = ['code', 'showLineNumbers', 'showCopyButton', 'dark'];
+
 export const HorizontalScroll: Story = {
   name: 'Horizontal scroll',
   args: { code: longLineSnippet },
   parameters: {
-    controls: { include: ['code'] },
+    controls: { include: codeBlockControls },
     docs: {
       description: {
         story:
@@ -110,10 +108,14 @@ export const HorizontalScroll: Story = {
 };
 
 export const WithHeader: Story = {
+  args: {
+    showCopyButton: false
+  },
+
   name: 'With header',
-  args: { showCopyButton: false },
+
   parameters: {
-    controls: { include: ['showCopyButton'] },
+    controls: { include: codeBlockControls },
     docs: {
       description: {
         story:
@@ -121,15 +123,15 @@ export const WithHeader: Story = {
       },
     },
   },
+
   render: (args) => (
     <CodeBlock {...args} className="min-w-[28rem]">
       <CodeBlockHeader>
         <span>Terminal</span>
-        <CodeBlockCopyButton />
       </CodeBlockHeader>
       <CodeBlockBody />
     </CodeBlock>
-  ),
+  )
 };
 
 export const WithLineNumbers: Story = {
@@ -137,10 +139,9 @@ export const WithLineNumbers: Story = {
   args: {
     code: multiLineSnippet,
     showLineNumbers: true,
-    showCopyButton: false,
   },
   parameters: {
-    controls: { include: ['code', 'showLineNumbers', 'showCopyButton'] },
+    controls: { include: codeBlockControls },
     docs: {
       description: {
         story:
@@ -152,7 +153,6 @@ export const WithLineNumbers: Story = {
     <CodeBlock {...args}>
       <CodeBlockHeader>
         <span>example.tsx</span>
-        <CodeBlockCopyButton />
       </CodeBlockHeader>
       <CodeBlockBody />
     </CodeBlock>
@@ -163,11 +163,10 @@ export const MaxLines: Story = {
   name: 'Max lines',
   args: {
     code: manyLinesSnippet,
-    showLineNumbers: true,
-    showCopyButton: false,
+    showLineNumbers: false,
   },
   parameters: {
-    controls: { include: ['code', 'showLineNumbers', 'showCopyButton'] },
+    controls: { include: codeBlockControls },
     docs: {
       description: {
         story:
@@ -179,7 +178,6 @@ export const MaxLines: Story = {
     <CodeBlock {...args}>
       <CodeBlockHeader>
         <span>steps.ts — 24 lines, capped at 8</span>
-        <CodeBlockCopyButton />
       </CodeBlockHeader>
       <CodeBlockBody maxLines={8} />
     </CodeBlock>
@@ -191,13 +189,10 @@ export const Dark: Story = {
   args: {
     code: multiLineSnippet,
     showLineNumbers: true,
-    showCopyButton: false,
     dark: true,
   },
   parameters: {
-    controls: {
-      include: ['code', 'showLineNumbers', 'showCopyButton', 'dark'],
-    },
+    controls: { include: codeBlockControls },
     docs: {
       description: {
         story:
@@ -209,7 +204,6 @@ export const Dark: Story = {
     <CodeBlock {...args}>
       <CodeBlockHeader>
         <span>example.tsx</span>
-        <CodeBlockCopyButton />
       </CodeBlockHeader>
       <CodeBlockBody />
     </CodeBlock>

--- a/stories/code-block.stories.tsx
+++ b/stories/code-block.stories.tsx
@@ -95,20 +95,14 @@ export const Default: Story = {
   ),
 };
 
-/**
- * `showCopyButton` governs the *floating* copy button on the root. Any story
- * whose header composes its own `CodeBlockCopyButton` fixes it to `false` in the
- * render — leaving it as a knob would offer to add a second, floating button
- * rather than to hide the one on screen.
- */
+/** Excludes `showCopyButton`: it adds a second, floating button, not hides one. */
 const composedCopyButtonControls = ['code', 'showLineNumbers', 'dark'];
 
 export const HorizontalScroll: Story = {
   name: 'Horizontal scroll',
   args: { code: longLineSnippet },
   parameters: {
-    // Header-less, so the floating copy button is the one on screen and its
-    // knob is live.
+    // Header-less, so the floating copy button is the one on screen.
     controls: {
       include: ['code', 'showCopyButton', 'showLineNumbers', 'dark'],
     },

--- a/stories/code-block.stories.tsx
+++ b/stories/code-block.stories.tsx
@@ -73,8 +73,8 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Basic: Story = {
-  name: 'Basic',
+export const Default: Story = {
+  name: 'Default',
   parameters: {
     docs: {
       description: {
@@ -94,6 +94,7 @@ export const HorizontalScroll: Story = {
   name: 'Horizontal scroll',
   args: { code: longLineSnippet },
   parameters: {
+    controls: { include: ['code'] },
     docs: {
       description: {
         story:
@@ -112,6 +113,7 @@ export const WithHeader: Story = {
   name: 'With header',
   args: { showCopyButton: false },
   parameters: {
+    controls: { include: ['showCopyButton'] },
     docs: {
       description: {
         story:
@@ -138,6 +140,7 @@ export const WithLineNumbers: Story = {
     showCopyButton: false,
   },
   parameters: {
+    controls: { include: ['code', 'showLineNumbers', 'showCopyButton'] },
     docs: {
       description: {
         story:
@@ -164,6 +167,7 @@ export const MaxLines: Story = {
     showCopyButton: false,
   },
   parameters: {
+    controls: { include: ['code', 'showLineNumbers', 'showCopyButton'] },
     docs: {
       description: {
         story:
@@ -191,6 +195,9 @@ export const Dark: Story = {
     dark: true,
   },
   parameters: {
+    controls: {
+      include: ['code', 'showLineNumbers', 'showCopyButton', 'dark'],
+    },
     docs: {
       description: {
         story:

--- a/stories/code-block.stories.tsx
+++ b/stories/code-block.stories.tsx
@@ -66,6 +66,12 @@ const meta = {
       control: 'boolean',
       table: { defaultValue: { summary: 'false' } },
     },
+    children: {
+      description:
+        'Composed content — a `CodeBlockBody`, optionally preceded by a `CodeBlockHeader` carrying a label and a `CodeBlockCopyButton`.',
+      control: false,
+    },
+    className: { table: { disable: true } },
   },
 } satisfies Meta<typeof CodeBlock>;
 
@@ -74,7 +80,6 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
-  name: 'Default',
   parameters: {
     docs: {
       description: {
@@ -197,7 +202,6 @@ export const MaxLines: Story = {
 };
 
 export const Dark: Story = {
-  name: 'Dark',
   args: {
     code: multiLineSnippet,
     showLineNumbers: true,

--- a/stories/dialog.stories.tsx
+++ b/stories/dialog.stories.tsx
@@ -1,5 +1,6 @@
 // biome-ignore-all lint/a11y/noNoninteractiveTabindex: dialog scroll containers need keyboard access.
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import type { ComponentProps } from 'react';
 import { useState } from 'react';
 import { expect, userEvent, within } from 'storybook/test';
 import { Button } from '@/ui/button';
@@ -14,6 +15,22 @@ import {
   DialogTrigger,
 } from '@/ui/dialog';
 
+// Base UI's `modal` is `boolean | 'trap-focus'`. Storybook args serialize as
+// strings, so the knob is keyed by string and mapped back to the real value.
+const MODAL_BY_KEY = {
+  true: true,
+  false: false,
+  'trap-focus': 'trap-focus',
+} as const;
+
+type DialogStoryArgs = ComponentProps<typeof DialogContent> &
+  Pick<
+    ComponentProps<typeof Dialog>,
+    'defaultOpen' | 'disablePointerDismissal' | 'open'
+  > & {
+    modal: keyof typeof MODAL_BY_KEY;
+  };
+
 const meta = {
   title: 'Components/Dialog',
   component: DialogContent,
@@ -26,11 +43,61 @@ const meta = {
       },
     },
   },
-} satisfies Meta<typeof DialogContent>;
+  args: { modal: 'true' },
+  argTypes: {
+    showCloseButton: {
+      description:
+        'Renders the default top-right close icon button inside the content surface.',
+      control: 'boolean',
+      table: { defaultValue: { summary: 'true' } },
+    },
+    defaultOpen: {
+      description:
+        'Set on `Dialog` (the root), not on `DialogContent` — opens the dialog on mount for an uncontrolled dialog.',
+      control: 'boolean',
+      table: { defaultValue: { summary: 'false' } },
+    },
+    open: {
+      description:
+        'Controlled open state, set on `Dialog`. Pair it with `onOpenChange`; left as a docs-only row here so the playground stays interactive.',
+      control: false,
+    },
+    modal: {
+      description:
+        'Set on `Dialog`. `true` traps focus and locks page scroll. `false` and `trap-focus` differ only in keyboard focus containment — `DialogContent` always renders a full-screen backdrop, so the page behind is never pointer-interactive regardless. Outside-press dismissal is governed by `disablePointerDismissal`.',
+      control: 'select',
+      options: ['true', 'false', 'trap-focus'],
+      table: {
+        type: { summary: "boolean | 'trap-focus'" },
+        defaultValue: { summary: 'true' },
+      },
+    },
+    disablePointerDismissal: {
+      description:
+        'Set on `Dialog`. Prevents the dialog from closing on an outside press — Escape and explicit closes still work.',
+      control: 'boolean',
+      table: { defaultValue: { summary: 'false' } },
+    },
+    className: { table: { disable: true } },
+    children: {
+      description:
+        'Composed content — `DialogHeader` (with `DialogTitle` and `DialogDescription`), the body, and `DialogFooter` with `DialogClose` actions.',
+      control: false,
+    },
+    render: {
+      description:
+        'Base UI render-prop composition. Swap the dialog content element while preserving its behavior, styling, and slot attributes.',
+      control: false,
+    },
+    portalProps: { table: { disable: true } },
+    viewportClassName: { table: { disable: true } },
+    overlayClassName: { table: { disable: true } },
+  },
+} satisfies Meta<DialogStoryArgs>;
 
 export default meta;
 
-type Story = StoryObj<typeof meta>;
+type Story = StoryObj<DialogStoryArgs>;
 
 const workspaceShareUrl = 'https://nebari.example/workspaces/analytics';
 
@@ -124,10 +191,18 @@ function ShareWorkspaceDialog() {
 }
 
 export const Default: Story = {
-  render: () => (
-    <Dialog>
+  // `defaultOpen` is read once on mount, so key the dialog on it to remount
+  // when the control changes — otherwise the knob would silently do nothing.
+  render: ({ defaultOpen, disablePointerDismissal, modal, open, ...args }) => (
+    <Dialog
+      key={String(defaultOpen)}
+      defaultOpen={defaultOpen}
+      disablePointerDismissal={disablePointerDismissal}
+      modal={MODAL_BY_KEY[modal]}
+      open={open}
+    >
       <DialogTrigger render={<Button />}>Open Dialog</DialogTrigger>
-      <DialogContent>
+      <DialogContent {...args}>
         <DialogHeader>
           <DialogTitle>Are you absolutely sure?</DialogTitle>
           <DialogDescription>
@@ -154,6 +229,7 @@ export const Default: Story = {
 
 export const GenericDialog: Story = {
   name: 'Generic Dialog',
+  parameters: { controls: { include: [] } },
   render: () => (
     <Dialog>
       <DialogTrigger render={<Button />}>Open Dialog</DialogTrigger>
@@ -178,6 +254,7 @@ export const GenericDialog: Story = {
 
 export const DeleteConfirmation: Story = {
   name: 'Delete Confirmation',
+  parameters: { controls: { include: [] } },
   render: () => (
     <Dialog>
       <DialogTrigger render={<Button variant="destructive" />}>
@@ -206,11 +283,13 @@ export const DeleteConfirmation: Story = {
 
 export const CustomCloseButton: Story = {
   name: 'Custom Close Button',
+  parameters: { controls: { include: [] } },
   render: () => <ShareWorkspaceDialog />,
 };
 
 export const StickyFooter: Story = {
   name: 'Sticky Footer',
+  parameters: { controls: { include: [] } },
   render: () => (
     <Dialog>
       <DialogTrigger render={<Button variant="outline" />}>
@@ -267,6 +346,7 @@ export const StickyFooter: Story = {
 
 export const ScrollableContent: Story = {
   name: 'Scrollable Content',
+  parameters: { controls: { include: [] } },
   render: () => (
     <Dialog>
       <DialogTrigger render={<Button variant="outline" />}>

--- a/stories/dialog.stories.tsx
+++ b/stories/dialog.stories.tsx
@@ -15,8 +15,7 @@ import {
   DialogTrigger,
 } from '@/ui/dialog';
 
-// Base UI's `modal` is `boolean | 'trap-focus'`. Storybook args serialize as
-// strings, so the knob is keyed by string and mapped back to the real value.
+// Storybook args serialize as strings, so `boolean | 'trap-focus'` is keyed by string.
 const MODAL_BY_KEY = {
   true: true,
   false: false,
@@ -54,7 +53,6 @@ function DialogRoot({
   );
 }
 
-/** Applies to every story: the root state knobs plus the close button. */
 const dialogControls = [
   'showCloseButton',
   'defaultOpen',
@@ -130,8 +128,7 @@ const meta = {
     overlayClassName: { table: { disable: true } },
   },
   decorators: [
-    // `defaultOpen` is read once on mount, so key the story on it to remount
-    // when the control changes — otherwise the knob would silently do nothing.
+    // `defaultOpen` is mount-only, so the key forces a remount when it changes.
     (Story, { args }) => <Story key={String(args.defaultOpen)} />,
   ],
 } satisfies Meta<DialogStoryArgs>;
@@ -313,7 +310,6 @@ export const DeleteConfirmation: Story = {
 };
 
 export const CustomCloseButton: Story = {
-  // The dialog fixes `showCloseButton={false}` — that is the story.
   parameters: {
     controls: {
       include: dialogControls.filter((prop) => prop !== 'showCloseButton'),

--- a/stories/dialog.stories.tsx
+++ b/stories/dialog.stories.tsx
@@ -1,6 +1,6 @@
 // biome-ignore-all lint/a11y/noNoninteractiveTabindex: dialog scroll containers need keyboard access.
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import type { ComponentProps } from 'react';
+import type { ComponentProps, ReactNode } from 'react';
 import { useState } from 'react';
 import { expect, userEvent, within } from 'storybook/test';
 import { Button } from '@/ui/button';
@@ -32,30 +32,26 @@ type DialogStoryArgs = ComponentProps<typeof DialogContent> &
   };
 
 /**
- * The knobs that live on `Dialog` (the root) rather than on `DialogContent`.
- * Every story threads them so its controls stay live; `defaultOpen` additionally
- * needs a `key` on the root, since it is only read on mount.
+ * Applies the knobs that live on `Dialog` (the root) rather than on
+ * `DialogContent`, so every story keeps them live off a plain `{...args}`.
  */
-type DialogRootProps = Pick<
-  ComponentProps<typeof Dialog>,
-  'defaultOpen' | 'disablePointerDismissal' | 'modal' | 'open'
->;
-
-function dialogRootProps({
+function DialogRoot({
+  children,
   defaultOpen,
   disablePointerDismissal,
   modal,
   open,
-}: Pick<
-  DialogStoryArgs,
-  'defaultOpen' | 'disablePointerDismissal' | 'modal' | 'open'
->): DialogRootProps {
-  return {
-    defaultOpen,
-    disablePointerDismissal,
-    modal: modal === undefined ? undefined : MODAL_BY_KEY[modal],
-    open,
-  };
+}: DialogStoryArgs & { children: ReactNode }) {
+  return (
+    <Dialog
+      defaultOpen={defaultOpen}
+      disablePointerDismissal={disablePointerDismissal}
+      modal={MODAL_BY_KEY[modal]}
+      open={open}
+    >
+      {children}
+    </Dialog>
+  );
 }
 
 /** Applies to every story: the root state knobs plus the close button. */
@@ -133,6 +129,11 @@ const meta = {
     viewportClassName: { table: { disable: true } },
     overlayClassName: { table: { disable: true } },
   },
+  decorators: [
+    // `defaultOpen` is read once on mount, so key the story on it to remount
+    // when the control changes — otherwise the knob would silently do nothing.
+    (Story, { args }) => <Story key={String(args.defaultOpen)} />,
+  ],
 } satisfies Meta<DialogStoryArgs>;
 
 export default meta;
@@ -183,7 +184,7 @@ async function copyToClipboard(text: string) {
   }
 }
 
-function ShareWorkspaceDialog(rootProps: DialogRootProps) {
+function ShareWorkspaceDialog(args: DialogStoryArgs) {
   const [copyState, setCopyState] = useState<'idle' | 'copied' | 'failed'>(
     'idle',
   );
@@ -198,7 +199,7 @@ function ShareWorkspaceDialog(rootProps: DialogRootProps) {
   }
 
   return (
-    <Dialog {...rootProps}>
+    <DialogRoot {...args}>
       <DialogTrigger render={<Button variant="outline" />}>Share</DialogTrigger>
       <DialogContent showCloseButton={false}>
         <DialogHeader>
@@ -226,23 +227,15 @@ function ShareWorkspaceDialog(rootProps: DialogRootProps) {
           </Button>
         </DialogFooter>
       </DialogContent>
-    </Dialog>
+    </DialogRoot>
   );
 }
 
 export const Default: Story = {
-  // `defaultOpen` is read once on mount, so key the dialog on it to remount
-  // when the control changes — otherwise the knob would silently do nothing.
-  render: ({ defaultOpen, disablePointerDismissal, modal, open, ...args }) => (
-    <Dialog
-      key={String(defaultOpen)}
-      defaultOpen={defaultOpen}
-      disablePointerDismissal={disablePointerDismissal}
-      modal={MODAL_BY_KEY[modal]}
-      open={open}
-    >
+  render: (args) => (
+    <DialogRoot {...args}>
       <DialogTrigger render={<Button />}>Open Dialog</DialogTrigger>
-      <DialogContent {...args}>
+      <DialogContent showCloseButton={args.showCloseButton}>
         <DialogHeader>
           <DialogTitle>Are you absolutely sure?</DialogTitle>
           <DialogDescription>
@@ -251,7 +244,7 @@ export const Default: Story = {
           </DialogDescription>
         </DialogHeader>
       </DialogContent>
-    </Dialog>
+    </DialogRoot>
   ),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
@@ -268,20 +261,11 @@ export const Default: Story = {
 };
 
 export const GenericDialog: Story = {
-  name: 'Generic Dialog',
   parameters: { controls: { include: dialogControls } },
-  render: ({ defaultOpen, disablePointerDismissal, modal, open, ...args }) => (
-    <Dialog
-      key={String(defaultOpen)}
-      {...dialogRootProps({
-        defaultOpen,
-        disablePointerDismissal,
-        modal,
-        open,
-      })}
-    >
+  render: (args) => (
+    <DialogRoot {...args}>
       <DialogTrigger render={<Button />}>Open Dialog</DialogTrigger>
-      <DialogContent {...args}>
+      <DialogContent showCloseButton={args.showCloseButton}>
         <DialogHeader>
           <DialogTitle>Dialog title</DialogTitle>
           <DialogDescription>
@@ -296,27 +280,18 @@ export const GenericDialog: Story = {
           <DialogClose render={<Button />}>Confirm</DialogClose>
         </DialogFooter>
       </DialogContent>
-    </Dialog>
+    </DialogRoot>
   ),
 };
 
 export const DeleteConfirmation: Story = {
-  name: 'Delete Confirmation',
   parameters: { controls: { include: dialogControls } },
-  render: ({ defaultOpen, disablePointerDismissal, modal, open, ...args }) => (
-    <Dialog
-      key={String(defaultOpen)}
-      {...dialogRootProps({
-        defaultOpen,
-        disablePointerDismissal,
-        modal,
-        open,
-      })}
-    >
+  render: (args) => (
+    <DialogRoot {...args}>
       <DialogTrigger render={<Button variant="destructive" />}>
         Delete Environment
       </DialogTrigger>
-      <DialogContent {...args}>
+      <DialogContent showCloseButton={args.showCloseButton}>
         <DialogHeader>
           <DialogTitle>Delete environment?</DialogTitle>
           <DialogDescription>
@@ -333,50 +308,30 @@ export const DeleteConfirmation: Story = {
           </DialogClose>
         </DialogFooter>
       </DialogContent>
-    </Dialog>
+    </DialogRoot>
   ),
 };
 
 export const CustomCloseButton: Story = {
-  name: 'Custom Close Button',
   // The dialog fixes `showCloseButton={false}` — that is the story.
   parameters: {
     controls: {
       include: dialogControls.filter((prop) => prop !== 'showCloseButton'),
     },
   },
-  render: ({ defaultOpen, disablePointerDismissal, modal, open }) => (
-    <ShareWorkspaceDialog
-      key={String(defaultOpen)}
-      {...dialogRootProps({
-        defaultOpen,
-        disablePointerDismissal,
-        modal,
-        open,
-      })}
-    />
-  ),
+  render: (args) => <ShareWorkspaceDialog {...args} />,
 };
 
 export const StickyFooter: Story = {
-  name: 'Sticky Footer',
   parameters: { controls: { include: dialogControls } },
-  render: ({ defaultOpen, disablePointerDismissal, modal, open, ...args }) => (
-    <Dialog
-      key={String(defaultOpen)}
-      {...dialogRootProps({
-        defaultOpen,
-        disablePointerDismissal,
-        modal,
-        open,
-      })}
-    >
+  render: (args) => (
+    <DialogRoot {...args}>
       <DialogTrigger render={<Button variant="outline" />}>
         Sticky Footer
       </DialogTrigger>
       <DialogContent
-        {...args}
         className="grid h-[min(calc(100vh-2rem),28rem)] grid-rows-[auto,minmax(0,1fr),auto] gap-0 p-0"
+        showCloseButton={args.showCloseButton}
       >
         <DialogHeader className="px-6 pt-6 pr-14 pb-4">
           <DialogTitle>Review environment changes</DialogTitle>
@@ -406,7 +361,7 @@ export const StickyFooter: Story = {
           <Button>Rebuild image</Button>
         </DialogFooter>
       </DialogContent>
-    </Dialog>
+    </DialogRoot>
   ),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
@@ -427,24 +382,15 @@ export const StickyFooter: Story = {
 };
 
 export const ScrollableContent: Story = {
-  name: 'Scrollable Content',
   parameters: { controls: { include: dialogControls } },
-  render: ({ defaultOpen, disablePointerDismissal, modal, open, ...args }) => (
-    <Dialog
-      key={String(defaultOpen)}
-      {...dialogRootProps({
-        defaultOpen,
-        disablePointerDismissal,
-        modal,
-        open,
-      })}
-    >
+  render: (args) => (
+    <DialogRoot {...args}>
       <DialogTrigger render={<Button variant="outline" />}>
         Scrollable Content
       </DialogTrigger>
       <DialogContent
-        {...args}
         className="grid h-[min(calc(100vh-2rem),32rem)] grid-rows-[auto,minmax(0,1fr)]"
+        showCloseButton={args.showCloseButton}
       >
         <DialogHeader>
           <DialogTitle>Workspace activity</DialogTitle>
@@ -465,7 +411,7 @@ export const ScrollableContent: Story = {
           ))}
         </section>
       </DialogContent>
-    </Dialog>
+    </DialogRoot>
   ),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);

--- a/stories/dialog.stories.tsx
+++ b/stories/dialog.stories.tsx
@@ -31,6 +31,41 @@ type DialogStoryArgs = ComponentProps<typeof DialogContent> &
     modal: keyof typeof MODAL_BY_KEY;
   };
 
+/**
+ * The knobs that live on `Dialog` (the root) rather than on `DialogContent`.
+ * Every story threads them so its controls stay live; `defaultOpen` additionally
+ * needs a `key` on the root, since it is only read on mount.
+ */
+type DialogRootProps = Pick<
+  ComponentProps<typeof Dialog>,
+  'defaultOpen' | 'disablePointerDismissal' | 'modal' | 'open'
+>;
+
+function dialogRootProps({
+  defaultOpen,
+  disablePointerDismissal,
+  modal,
+  open,
+}: Pick<
+  DialogStoryArgs,
+  'defaultOpen' | 'disablePointerDismissal' | 'modal' | 'open'
+>): DialogRootProps {
+  return {
+    defaultOpen,
+    disablePointerDismissal,
+    modal: modal === undefined ? undefined : MODAL_BY_KEY[modal],
+    open,
+  };
+}
+
+/** Applies to every story: the root state knobs plus the close button. */
+const dialogControls = [
+  'showCloseButton',
+  'defaultOpen',
+  'modal',
+  'disablePointerDismissal',
+];
+
 const meta = {
   title: 'Components/Dialog',
   component: DialogContent,
@@ -43,7 +78,12 @@ const meta = {
       },
     },
   },
-  args: { modal: 'true' },
+  args: {
+    defaultOpen: false,
+    disablePointerDismissal: false,
+    modal: 'true',
+    showCloseButton: true,
+  },
   argTypes: {
     showCloseButton: {
       description:
@@ -143,7 +183,7 @@ async function copyToClipboard(text: string) {
   }
 }
 
-function ShareWorkspaceDialog() {
+function ShareWorkspaceDialog(rootProps: DialogRootProps) {
   const [copyState, setCopyState] = useState<'idle' | 'copied' | 'failed'>(
     'idle',
   );
@@ -158,7 +198,7 @@ function ShareWorkspaceDialog() {
   }
 
   return (
-    <Dialog>
+    <Dialog {...rootProps}>
       <DialogTrigger render={<Button variant="outline" />}>Share</DialogTrigger>
       <DialogContent showCloseButton={false}>
         <DialogHeader>
@@ -229,11 +269,19 @@ export const Default: Story = {
 
 export const GenericDialog: Story = {
   name: 'Generic Dialog',
-  parameters: { controls: { include: [] } },
-  render: () => (
-    <Dialog>
+  parameters: { controls: { include: dialogControls } },
+  render: ({ defaultOpen, disablePointerDismissal, modal, open, ...args }) => (
+    <Dialog
+      key={String(defaultOpen)}
+      {...dialogRootProps({
+        defaultOpen,
+        disablePointerDismissal,
+        modal,
+        open,
+      })}
+    >
       <DialogTrigger render={<Button />}>Open Dialog</DialogTrigger>
-      <DialogContent>
+      <DialogContent {...args}>
         <DialogHeader>
           <DialogTitle>Dialog title</DialogTitle>
           <DialogDescription>
@@ -254,13 +302,21 @@ export const GenericDialog: Story = {
 
 export const DeleteConfirmation: Story = {
   name: 'Delete Confirmation',
-  parameters: { controls: { include: [] } },
-  render: () => (
-    <Dialog>
+  parameters: { controls: { include: dialogControls } },
+  render: ({ defaultOpen, disablePointerDismissal, modal, open, ...args }) => (
+    <Dialog
+      key={String(defaultOpen)}
+      {...dialogRootProps({
+        defaultOpen,
+        disablePointerDismissal,
+        modal,
+        open,
+      })}
+    >
       <DialogTrigger render={<Button variant="destructive" />}>
         Delete Environment
       </DialogTrigger>
-      <DialogContent>
+      <DialogContent {...args}>
         <DialogHeader>
           <DialogTitle>Delete environment?</DialogTitle>
           <DialogDescription>
@@ -283,19 +339,45 @@ export const DeleteConfirmation: Story = {
 
 export const CustomCloseButton: Story = {
   name: 'Custom Close Button',
-  parameters: { controls: { include: [] } },
-  render: () => <ShareWorkspaceDialog />,
+  // The dialog fixes `showCloseButton={false}` — that is the story.
+  parameters: {
+    controls: {
+      include: dialogControls.filter((prop) => prop !== 'showCloseButton'),
+    },
+  },
+  render: ({ defaultOpen, disablePointerDismissal, modal, open }) => (
+    <ShareWorkspaceDialog
+      key={String(defaultOpen)}
+      {...dialogRootProps({
+        defaultOpen,
+        disablePointerDismissal,
+        modal,
+        open,
+      })}
+    />
+  ),
 };
 
 export const StickyFooter: Story = {
   name: 'Sticky Footer',
-  parameters: { controls: { include: [] } },
-  render: () => (
-    <Dialog>
+  parameters: { controls: { include: dialogControls } },
+  render: ({ defaultOpen, disablePointerDismissal, modal, open, ...args }) => (
+    <Dialog
+      key={String(defaultOpen)}
+      {...dialogRootProps({
+        defaultOpen,
+        disablePointerDismissal,
+        modal,
+        open,
+      })}
+    >
       <DialogTrigger render={<Button variant="outline" />}>
         Sticky Footer
       </DialogTrigger>
-      <DialogContent className="grid h-[min(calc(100vh-2rem),28rem)] grid-rows-[auto,minmax(0,1fr),auto] gap-0 p-0">
+      <DialogContent
+        {...args}
+        className="grid h-[min(calc(100vh-2rem),28rem)] grid-rows-[auto,minmax(0,1fr),auto] gap-0 p-0"
+      >
         <DialogHeader className="px-6 pt-6 pr-14 pb-4">
           <DialogTitle>Review environment changes</DialogTitle>
           <DialogDescription>
@@ -346,13 +428,24 @@ export const StickyFooter: Story = {
 
 export const ScrollableContent: Story = {
   name: 'Scrollable Content',
-  parameters: { controls: { include: [] } },
-  render: () => (
-    <Dialog>
+  parameters: { controls: { include: dialogControls } },
+  render: ({ defaultOpen, disablePointerDismissal, modal, open, ...args }) => (
+    <Dialog
+      key={String(defaultOpen)}
+      {...dialogRootProps({
+        defaultOpen,
+        disablePointerDismissal,
+        modal,
+        open,
+      })}
+    >
       <DialogTrigger render={<Button variant="outline" />}>
         Scrollable Content
       </DialogTrigger>
-      <DialogContent className="grid h-[min(calc(100vh-2rem),32rem)] grid-rows-[auto,minmax(0,1fr)]">
+      <DialogContent
+        {...args}
+        className="grid h-[min(calc(100vh-2rem),32rem)] grid-rows-[auto,minmax(0,1fr)]"
+      >
         <DialogHeader>
           <DialogTitle>Workspace activity</DialogTitle>
           <DialogDescription>

--- a/stories/dialog.stories.tsx
+++ b/stories/dialog.stories.tsx
@@ -53,13 +53,6 @@ function DialogRoot({
   );
 }
 
-const dialogControls = [
-  'showCloseButton',
-  'defaultOpen',
-  'modal',
-  'disablePointerDismissal',
-];
-
 const meta = {
   title: 'Components/Dialog',
   component: DialogContent,
@@ -258,7 +251,7 @@ export const Default: Story = {
 };
 
 export const GenericDialog: Story = {
-  parameters: { controls: { include: dialogControls } },
+  parameters: { controls: { include: [] } },
   render: (args) => (
     <DialogRoot {...args}>
       <DialogTrigger render={<Button />}>Open Dialog</DialogTrigger>
@@ -282,7 +275,7 @@ export const GenericDialog: Story = {
 };
 
 export const DeleteConfirmation: Story = {
-  parameters: { controls: { include: dialogControls } },
+  parameters: { controls: { include: [] } },
   render: (args) => (
     <DialogRoot {...args}>
       <DialogTrigger render={<Button variant="destructive" />}>
@@ -312,14 +305,14 @@ export const DeleteConfirmation: Story = {
 export const CustomCloseButton: Story = {
   parameters: {
     controls: {
-      include: dialogControls.filter((prop) => prop !== 'showCloseButton'),
+      include: [],
     },
   },
   render: (args) => <ShareWorkspaceDialog {...args} />,
 };
 
 export const StickyFooter: Story = {
-  parameters: { controls: { include: dialogControls } },
+  parameters: { controls: { include: [] } },
   render: (args) => (
     <DialogRoot {...args}>
       <DialogTrigger render={<Button variant="outline" />}>
@@ -378,7 +371,7 @@ export const StickyFooter: Story = {
 };
 
 export const ScrollableContent: Story = {
-  parameters: { controls: { include: dialogControls } },
+  parameters: { controls: { include: [] } },
   render: (args) => (
     <DialogRoot {...args}>
       <DialogTrigger render={<Button variant="outline" />}>

--- a/stories/drawer.stories.tsx
+++ b/stories/drawer.stories.tsx
@@ -27,8 +27,6 @@ type DrawerStoryArgs = {
   side: DrawerSide;
 };
 
-const drawerControls = ['side', 'showCloseButton', 'showSwipeHandle'];
-
 const meta = {
   title: 'Components/Drawer',
   parameters: {
@@ -59,7 +57,7 @@ const meta = {
       table: { defaultValue: { summary: 'true' } },
     },
     showSwipeHandle: {
-      control: 'inline-radio',
+      control: 'select',
       description:
         'Shows the grab handle. `auto` leaves it to the drawer — shown for bottom drawers, hidden for side drawers.',
       options: ['auto', 'shown', 'hidden'],
@@ -228,7 +226,7 @@ export const Default: Story = {
 
 export const BottomSheet: Story = {
   name: 'Bottom sheet',
-  parameters: { controls: { include: drawerControls } },
+  parameters: { controls: { include: [] } },
   args: {
     side: 'bottom',
   },
@@ -244,7 +242,7 @@ export const BottomSheet: Story = {
 
 export const LongContent: Story = {
   name: 'Long content',
-  parameters: { controls: { include: drawerControls } },
+  parameters: { controls: { include: [] } },
   render: ({ showCloseButton, showSwipeHandle, side }) => (
     <Drawer {...drawerProps({ showSwipeHandle, side })}>
       <DrawerTrigger render={<Button variant="outline" />}>
@@ -310,7 +308,7 @@ export const LongContent: Story = {
 
 export const NestedDrawer: Story = {
   name: 'Multi nested drawer',
-  parameters: { controls: { include: drawerControls } },
+  parameters: { controls: { include: [] } },
   render: ({ showCloseButton, showSwipeHandle, side }) => (
     <Drawer {...drawerProps({ showSwipeHandle, side })}>
       <DrawerTrigger render={<Button variant="outline" />}>

--- a/stories/drawer.stories.tsx
+++ b/stories/drawer.stories.tsx
@@ -9,16 +9,29 @@ import {
   DrawerDescription,
   DrawerFooter,
   DrawerHeader,
-  type DrawerProps,
   type DrawerSide,
   DrawerTitle,
   DrawerTrigger,
 } from '@/ui/drawer';
 
-type DrawerStoryArgs = Pick<DrawerProps, 'showSwipeHandle'> & {
+// Omitting `showSwipeHandle` is the meaningful default — the drawer shows the
+// handle for bottom drawers and hides it for side drawers — so the knob models
+// that as an explicit `auto` option. An unset arg would render as a
+// click-to-reveal control with no way back to the automatic behavior.
+const SWIPE_HANDLE_BY_KEY = {
+  auto: undefined,
+  shown: true,
+  hidden: false,
+} as const;
+
+type DrawerStoryArgs = {
   showCloseButton: boolean;
+  showSwipeHandle: keyof typeof SWIPE_HANDLE_BY_KEY;
   side: DrawerSide;
 };
+
+/** Applies to every story: the side plus both chrome toggles. */
+const drawerControls = ['side', 'showCloseButton', 'showSwipeHandle'];
 
 const meta = {
   title: 'Components/Drawer',
@@ -33,6 +46,7 @@ const meta = {
   },
   args: {
     showCloseButton: true,
+    showSwipeHandle: 'auto',
     side: 'right',
   },
   argTypes: {
@@ -49,17 +63,22 @@ const meta = {
       table: { defaultValue: { summary: 'true' } },
     },
     showSwipeHandle: {
-      control: 'boolean',
+      control: 'inline-radio',
       description:
-        'Shows the grab handle. Defaults to true for bottom drawers and false for side drawers.',
-      table: { defaultValue: { summary: 'auto' } },
+        'Shows the grab handle. `auto` leaves it to the drawer — shown for bottom drawers, hidden for side drawers.',
+      options: ['auto', 'shown', 'hidden'],
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: 'auto' },
+      },
     },
   },
 } satisfies Meta<DrawerStoryArgs>;
 
 export default meta;
 
-type Story = StoryObj<typeof meta>;
+// `meta` has no `component`, so the story args come from the story-args type.
+type Story = StoryObj<DrawerStoryArgs>;
 
 const LONG_CONTENT_SECTIONS = [
   [
@@ -110,12 +129,14 @@ const LONG_CONTENT_SECTIONS = [
 ];
 
 function drawerProps({
-  showSwipeHandle,
+  showSwipeHandle = 'auto',
   side = 'right',
 }: Partial<Pick<DrawerStoryArgs, 'showSwipeHandle' | 'side'>>) {
+  const resolved = SWIPE_HANDLE_BY_KEY[showSwipeHandle];
+
   return {
     side,
-    ...(showSwipeHandle === undefined ? {} : { showSwipeHandle }),
+    ...(resolved === undefined ? {} : { showSwipeHandle: resolved }),
   };
 }
 
@@ -212,7 +233,7 @@ export const Default: Story = {
 
 export const BottomSheet: Story = {
   name: 'Bottom sheet',
-  parameters: { controls: { include: ['side'] } },
+  parameters: { controls: { include: drawerControls } },
   args: {
     side: 'bottom',
   },
@@ -228,13 +249,16 @@ export const BottomSheet: Story = {
 
 export const LongContent: Story = {
   name: 'Long content',
-  parameters: { controls: { include: [] } },
-  render: () => (
-    <Drawer side="right">
+  parameters: { controls: { include: drawerControls } },
+  render: ({ showCloseButton, showSwipeHandle, side }) => (
+    <Drawer {...drawerProps({ showSwipeHandle, side })}>
       <DrawerTrigger render={<Button variant="outline" />}>
         Review workspace
       </DrawerTrigger>
-      <DrawerContent className="h-dvh max-h-dvh" showCloseButton>
+      <DrawerContent
+        className="h-dvh max-h-dvh"
+        showCloseButton={showCloseButton}
+      >
         <DrawerHeader>
           <div className="min-w-0 flex-1">
             <DrawerTitle>Workspace review</DrawerTitle>
@@ -291,13 +315,13 @@ export const LongContent: Story = {
 
 export const NestedDrawer: Story = {
   name: 'Multi nested drawer',
-  parameters: { controls: { include: [] } },
-  render: () => (
-    <Drawer side="right">
+  parameters: { controls: { include: drawerControls } },
+  render: ({ showCloseButton, showSwipeHandle, side }) => (
+    <Drawer {...drawerProps({ showSwipeHandle, side })}>
       <DrawerTrigger render={<Button variant="outline" />}>
         Environment settings
       </DrawerTrigger>
-      <DrawerContent>
+      <DrawerContent showCloseButton={showCloseButton}>
         <DrawerHeader>
           <div className="min-w-0 flex-1">
             <DrawerTitle>Environment settings</DrawerTitle>
@@ -318,7 +342,7 @@ export const NestedDrawer: Story = {
                 Collaborator access and invitation settings.
               </div>
             </div>
-            <Drawer side="right">
+            <Drawer {...drawerProps({ showSwipeHandle, side })}>
               <DrawerTrigger render={<Button variant="outline" />}>
                 Advanced settings
               </DrawerTrigger>
@@ -348,7 +372,7 @@ export const NestedDrawer: Story = {
                         </div>
                       </div>
                     ))}
-                    <Drawer side="right">
+                    <Drawer {...drawerProps({ showSwipeHandle, side })}>
                       <DrawerTrigger render={<Button variant="outline" />}>
                         Rebuild policy
                       </DrawerTrigger>

--- a/stories/drawer.stories.tsx
+++ b/stories/drawer.stories.tsx
@@ -212,6 +212,7 @@ export const Default: Story = {
 
 export const BottomSheet: Story = {
   name: 'Bottom sheet',
+  parameters: { controls: { include: ['side'] } },
   args: {
     side: 'bottom',
   },
@@ -227,19 +228,13 @@ export const BottomSheet: Story = {
 
 export const LongContent: Story = {
   name: 'Long content',
-  render: ({
-    showCloseButton = true,
-    showSwipeHandle,
-    side = 'right',
-  }: Partial<DrawerStoryArgs>) => (
-    <Drawer {...drawerProps({ showSwipeHandle, side })}>
+  parameters: { controls: { include: [] } },
+  render: () => (
+    <Drawer side="right">
       <DrawerTrigger render={<Button variant="outline" />}>
         Review workspace
       </DrawerTrigger>
-      <DrawerContent
-        className="h-dvh max-h-dvh"
-        showCloseButton={showCloseButton}
-      >
+      <DrawerContent className="h-dvh max-h-dvh" showCloseButton>
         <DrawerHeader>
           <div className="min-w-0 flex-1">
             <DrawerTitle>Workspace review</DrawerTitle>
@@ -296,6 +291,7 @@ export const LongContent: Story = {
 
 export const NestedDrawer: Story = {
   name: 'Multi nested drawer',
+  parameters: { controls: { include: [] } },
   render: () => (
     <Drawer side="right">
       <DrawerTrigger render={<Button variant="outline" />}>

--- a/stories/drawer.stories.tsx
+++ b/stories/drawer.stories.tsx
@@ -14,10 +14,7 @@ import {
   DrawerTrigger,
 } from '@/ui/drawer';
 
-// Omitting `showSwipeHandle` is the meaningful default — the drawer shows the
-// handle for bottom drawers and hides it for side drawers — so the knob models
-// that as an explicit `auto` option. An unset arg would render as a
-// click-to-reveal control with no way back to the automatic behavior.
+// `auto` keeps the per-side default (shown for bottom) reachable from the knob.
 const SWIPE_HANDLE_BY_KEY = {
   auto: undefined,
   shown: true,
@@ -30,7 +27,6 @@ type DrawerStoryArgs = {
   side: DrawerSide;
 };
 
-/** Applies to every story: the side plus both chrome toggles. */
 const drawerControls = ['side', 'showCloseButton', 'showSwipeHandle'];
 
 const meta = {
@@ -77,7 +73,6 @@ const meta = {
 
 export default meta;
 
-// `meta` has no `component`, so the story args come from the story-args type.
 type Story = StoryObj<DrawerStoryArgs>;
 
 const LONG_CONTENT_SECTIONS = [

--- a/stories/dropdown-menu.stories.tsx
+++ b/stories/dropdown-menu.stories.tsx
@@ -105,7 +105,6 @@ export const Default: Story = {
 };
 
 export const WithCheckboxItems: Story = {
-  // The menu items are the subject; the trigger knobs still apply.
   parameters: {
     controls: { include: ['variant', 'showExpandIcon', 'disabled'] },
   },
@@ -165,7 +164,6 @@ export const WithSubmenu: Story = {
 };
 
 export const TriggerVariants: Story = {
-  // Each trigger fixes its own `variant` and `showExpandIcon`.
   parameters: { controls: { include: ['disabled'] } },
   render: ({ disabled }) => (
     <div className="flex items-center gap-6">

--- a/stories/dropdown-menu.stories.tsx
+++ b/stories/dropdown-menu.stories.tsx
@@ -106,7 +106,7 @@ export const Default: Story = {
 
 export const WithCheckboxItems: Story = {
   parameters: {
-    controls: { include: ['variant', 'showExpandIcon', 'disabled'] },
+    controls: { include: [] },
   },
   render: ({ children: _children, ...args }) => {
     const [showLineNumbers, setShowLineNumbers] = useState(true);
@@ -141,7 +141,7 @@ export const WithCheckboxItems: Story = {
 
 export const WithSubmenu: Story = {
   parameters: {
-    controls: { include: ['variant', 'showExpandIcon', 'disabled'] },
+    controls: { include: [] },
   },
   render: ({ children: _children, ...args }) => (
     <DropdownMenu>
@@ -164,7 +164,7 @@ export const WithSubmenu: Story = {
 };
 
 export const TriggerVariants: Story = {
-  parameters: { controls: { include: ['disabled'] } },
+  parameters: { controls: { include: [] } },
   render: ({ disabled }) => (
     <div className="flex items-center gap-6">
       <DropdownMenu>

--- a/stories/dropdown-menu.stories.tsx
+++ b/stories/dropdown-menu.stories.tsx
@@ -35,10 +35,6 @@ const meta = {
       control: 'text',
       description: 'Visible trigger label.',
     },
-    showExpandIcon: {
-      control: 'boolean',
-      description: 'Shows trailing expand icon on trigger.',
-    },
     variant: {
       control: 'select',
       options: [
@@ -49,7 +45,31 @@ const meta = {
         'ghost',
         'link',
       ],
-      description: 'Trigger visual style variant.',
+      description:
+        'Trigger visual style variant. Every variant other than `default` defers to the matching `Button` variant.',
+      table: { defaultValue: { summary: 'default' } },
+    },
+    showExpandIcon: {
+      control: 'boolean',
+      description:
+        'Shows the trailing chevron expand icon on the trigger, and adds the gap for it.',
+      table: { defaultValue: { summary: 'false' } },
+    },
+    expandIcon: {
+      control: false,
+      description:
+        'Replaces the default `chevrons-up-down` icon shown when `showExpandIcon` is set.',
+    },
+    disabled: {
+      control: 'boolean',
+      description: 'Disables the trigger so the menu can no longer be opened.',
+      table: { defaultValue: { summary: 'false' } },
+    },
+    className: { table: { disable: true } },
+    render: {
+      description:
+        'Base UI render-prop composition. Swap the trigger element while preserving its behavior, styling, and slot attributes.',
+      control: false,
     },
   },
 } satisfies Meta<typeof DropdownMenuTrigger>;
@@ -84,6 +104,7 @@ export const Default: Story = {
 };
 
 export const WithCheckboxItems: Story = {
+  parameters: { controls: { include: [] } },
   render: () => {
     const [showLineNumbers, setShowLineNumbers] = useState(true);
     const [wrapLines, setWrapLines] = useState(false);
@@ -116,6 +137,7 @@ export const WithCheckboxItems: Story = {
 };
 
 export const WithSubmenu: Story = {
+  parameters: { controls: { include: [] } },
   render: () => (
     <DropdownMenu>
       <DropdownMenuTrigger>File</DropdownMenuTrigger>
@@ -137,6 +159,7 @@ export const WithSubmenu: Story = {
 };
 
 export const TriggerVariants: Story = {
+  parameters: { controls: { include: [] } },
   render: () => (
     <div className="flex items-center gap-6">
       <DropdownMenu>

--- a/stories/dropdown-menu.stories.tsx
+++ b/stories/dropdown-menu.stories.tsx
@@ -27,6 +27,7 @@ const meta = {
   },
   args: {
     children: 'Open',
+    disabled: false,
     showExpandIcon: false,
     variant: 'default',
   },
@@ -104,14 +105,17 @@ export const Default: Story = {
 };
 
 export const WithCheckboxItems: Story = {
-  parameters: { controls: { include: [] } },
-  render: () => {
+  // The menu items are the subject; the trigger knobs still apply.
+  parameters: {
+    controls: { include: ['variant', 'showExpandIcon', 'disabled'] },
+  },
+  render: ({ children: _children, ...args }) => {
     const [showLineNumbers, setShowLineNumbers] = useState(true);
     const [wrapLines, setWrapLines] = useState(false);
 
     return (
       <DropdownMenu>
-        <DropdownMenuTrigger>Options</DropdownMenuTrigger>
+        <DropdownMenuTrigger {...args}>Options</DropdownMenuTrigger>
         <DropdownMenuPortal>
           <DropdownMenuContent>
             <DropdownMenuGroup>
@@ -137,10 +141,12 @@ export const WithCheckboxItems: Story = {
 };
 
 export const WithSubmenu: Story = {
-  parameters: { controls: { include: [] } },
-  render: () => (
+  parameters: {
+    controls: { include: ['variant', 'showExpandIcon', 'disabled'] },
+  },
+  render: ({ children: _children, ...args }) => (
     <DropdownMenu>
-      <DropdownMenuTrigger>File</DropdownMenuTrigger>
+      <DropdownMenuTrigger {...args}>File</DropdownMenuTrigger>
       <DropdownMenuPortal>
         <DropdownMenuContent>
           <DropdownMenuItem>New file</DropdownMenuItem>
@@ -159,11 +165,14 @@ export const WithSubmenu: Story = {
 };
 
 export const TriggerVariants: Story = {
-  parameters: { controls: { include: [] } },
-  render: () => (
+  // Each trigger fixes its own `variant` and `showExpandIcon`.
+  parameters: { controls: { include: ['disabled'] } },
+  render: ({ disabled }) => (
     <div className="flex items-center gap-6">
       <DropdownMenu>
-        <DropdownMenuTrigger showExpandIcon>Open</DropdownMenuTrigger>
+        <DropdownMenuTrigger disabled={disabled} showExpandIcon>
+          Open
+        </DropdownMenuTrigger>
         <DropdownMenuPortal>
           <DropdownMenuContent>
             <DropdownMenuItem>Dropdown Menu Item Text</DropdownMenuItem>
@@ -172,7 +181,7 @@ export const TriggerVariants: Story = {
       </DropdownMenu>
 
       <DropdownMenu>
-        <DropdownMenuTrigger showExpandIcon variant="ghost">
+        <DropdownMenuTrigger disabled={disabled} showExpandIcon variant="ghost">
           Open
         </DropdownMenuTrigger>
         <DropdownMenuPortal>

--- a/stories/field.stories.tsx
+++ b/stories/field.stories.tsx
@@ -57,7 +57,7 @@ export const Default: Story = {
 
 /** Inline layout — label and description on the left, control on the right. */
 export const Inline: Story = {
-  parameters: { controls: { include: ['disabled', 'invalid'] } },
+  parameters: { controls: { include: [] } },
   render: (args) => (
     <Field
       {...args}

--- a/stories/field.stories.tsx
+++ b/stories/field.stories.tsx
@@ -6,6 +6,37 @@ const meta = {
   title: 'Components/Field',
   component: Field,
   parameters: { layout: 'centered' },
+  argTypes: {
+    name: {
+      description:
+        'Form field name. Base UI uses it for form submission and to key validation state.',
+      control: 'text',
+    },
+    disabled: {
+      description:
+        'Disables the whole field. `FieldLabel` picks up `data-disabled` and dims alongside the control.',
+      control: 'boolean',
+      table: { defaultValue: { summary: 'false' } },
+    },
+    invalid: {
+      description:
+        'Forces the field into its invalid state, which controls-inside-the-field read via `data-invalid` and which reveals a matching `FieldError`.',
+      control: 'boolean',
+      table: { defaultValue: { summary: 'false' } },
+    },
+    className: { table: { disable: true } },
+    children: {
+      description:
+        'Composed content — a `FieldLabel`, the control itself, and a `FieldDescription` or `FieldError`. Base UI wires the label, description, and control together through field context.',
+      control: false,
+    },
+    render: {
+      description:
+        'Base UI render-prop composition. Swap the field container element while preserving field context, styling, and slot attributes.',
+      control: false,
+    },
+    validate: { table: { disable: true } },
+  },
 } satisfies Meta<typeof Field>;
 
 export default meta;
@@ -14,8 +45,8 @@ type Story = StoryObj<typeof meta>;
 
 /** Vertical stack — the default layout for a labeled control. */
 export const Default: Story = {
-  render: () => (
-    <Field className="w-64">
+  render: (args) => (
+    <Field {...args} className="w-64">
       <FieldLabel>Enable copy</FieldLabel>
       <Switch defaultChecked />
       <FieldDescription>Allow users to copy this environment</FieldDescription>
@@ -25,6 +56,7 @@ export const Default: Story = {
 
 /** Inline layout — label and description on the left, control on the right. */
 export const Inline: Story = {
+  parameters: { controls: { include: [] } },
   render: () => (
     <Field className="w-64 flex-row items-start justify-between gap-4">
       <div className="flex flex-col gap-0.5">

--- a/stories/field.stories.tsx
+++ b/stories/field.stories.tsx
@@ -6,6 +6,7 @@ const meta = {
   title: 'Components/Field',
   component: Field,
   parameters: { layout: 'centered' },
+  args: { disabled: false, invalid: false },
   argTypes: {
     name: {
       description:
@@ -56,9 +57,12 @@ export const Default: Story = {
 
 /** Inline layout — label and description on the left, control on the right. */
 export const Inline: Story = {
-  parameters: { controls: { include: [] } },
-  render: () => (
-    <Field className="w-64 flex-row items-start justify-between gap-4">
+  parameters: { controls: { include: ['disabled', 'invalid'] } },
+  render: (args) => (
+    <Field
+      {...args}
+      className="w-64 flex-row items-start justify-between gap-4"
+    >
       <div className="flex flex-col gap-0.5">
         <FieldLabel>Enable copy</FieldLabel>
         <FieldDescription>

--- a/stories/input.stories.tsx
+++ b/stories/input.stories.tsx
@@ -61,8 +61,7 @@ const meta = {
     className: { table: { disable: true } },
   },
   decorators: [
-    // `defaultValue` is read once on mount, so key the story on it to remount
-    // when the control changes — otherwise the knob would silently do nothing.
+    // `defaultValue` is mount-only, so the key forces a remount when it changes.
     (Story, { args }) => (
       <div className="w-64">
         <Story key={String(args.defaultValue)} />

--- a/stories/input.stories.tsx
+++ b/stories/input.stories.tsx
@@ -78,12 +78,12 @@ export const Default: Story = {};
 
 export const Filled: Story = {
   args: { defaultValue: 'you@nebari.dev' },
-  parameters: { controls: { include: ['defaultValue', 'type'] } },
+  parameters: { controls: { include: [] } },
 };
 
 export const Disabled: Story = {
   args: { disabled: true },
-  parameters: { controls: { include: ['disabled', 'defaultValue'] } },
+  parameters: { controls: { include: [] } },
 };
 
 /**
@@ -93,7 +93,7 @@ export const Disabled: Story = {
  */
 export const WithError: Story = {
   args: { 'aria-invalid': true, defaultValue: 'invalid@email' },
-  parameters: { controls: { include: ['aria-invalid', 'defaultValue'] } },
+  parameters: { controls: { include: [] } },
   render: (args) => (
     <Field>
       <FieldLabel>Email</FieldLabel>
@@ -107,7 +107,7 @@ export const WithError: Story = {
 export const WithField: Story = {
   args: { placeholder: 'you@nebari.dev' },
   parameters: {
-    controls: { include: ['placeholder', 'disabled', 'required'] },
+    controls: { include: [] },
   },
   render: (args) => (
     <Field>

--- a/stories/input.stories.tsx
+++ b/stories/input.stories.tsx
@@ -6,7 +6,14 @@ const meta = {
   title: 'Components/Input',
   component: Input,
   parameters: { layout: 'centered' },
-  args: { placeholder: 'Placeholder text' },
+  args: {
+    'aria-invalid': false,
+    disabled: false,
+    placeholder: 'Placeholder text',
+    readOnly: false,
+    required: false,
+    type: 'text',
+  },
   argTypes: {
     placeholder: {
       description: 'Hint text shown while the input is empty.',
@@ -72,12 +79,12 @@ export const Default: Story = {};
 
 export const Filled: Story = {
   args: { defaultValue: 'you@nebari.dev' },
-  parameters: { controls: { include: ['defaultValue'] } },
+  parameters: { controls: { include: ['defaultValue', 'type'] } },
 };
 
 export const Disabled: Story = {
   args: { disabled: true },
-  parameters: { controls: { include: ['disabled'] } },
+  parameters: { controls: { include: ['disabled', 'defaultValue'] } },
 };
 
 /**
@@ -86,11 +93,12 @@ export const Disabled: Story = {
  * than color alone (WCAG 1.4.1).
  */
 export const WithError: Story = {
-  parameters: { controls: { include: [] } },
-  render: () => (
+  args: { 'aria-invalid': true, defaultValue: 'invalid@email' },
+  parameters: { controls: { include: ['aria-invalid', 'defaultValue'] } },
+  render: (args) => (
     <Field>
       <FieldLabel>Email</FieldLabel>
-      <Input defaultValue="invalid@email" aria-invalid />
+      <Input {...args} />
       <FieldError match>Enter a valid email address.</FieldError>
     </Field>
   ),
@@ -98,11 +106,14 @@ export const WithError: Story = {
 
 /** Composed in a `Field` — label, description, and control auto-associate. */
 export const WithField: Story = {
-  parameters: { controls: { include: [] } },
-  render: () => (
+  args: { placeholder: 'you@nebari.dev' },
+  parameters: {
+    controls: { include: ['placeholder', 'disabled', 'required'] },
+  },
+  render: (args) => (
     <Field>
       <FieldLabel>Email</FieldLabel>
-      <Input placeholder="you@nebari.dev" />
+      <Input {...args} />
       <FieldDescription>We'll never share your email.</FieldDescription>
     </Field>
   ),

--- a/stories/input.stories.tsx
+++ b/stories/input.stories.tsx
@@ -7,10 +7,58 @@ const meta = {
   component: Input,
   parameters: { layout: 'centered' },
   args: { placeholder: 'Placeholder text' },
+  argTypes: {
+    placeholder: {
+      description: 'Hint text shown while the input is empty.',
+      control: 'text',
+    },
+    defaultValue: {
+      description: 'Initial value when the input is uncontrolled.',
+      control: 'text',
+    },
+    value: {
+      description:
+        'Controlled value. Pair it with `onChange`; left as a docs-only row here so the playground stays interactive.',
+      control: false,
+    },
+    type: {
+      description:
+        'Native input type. Drives the on-screen keyboard and browser-level validation.',
+      control: 'select',
+      options: ['text', 'email', 'password', 'number', 'search', 'tel', 'url'],
+      table: { defaultValue: { summary: 'text' } },
+    },
+    disabled: {
+      description:
+        'Dims the input to `bg-muted`, blocks pointer events, and removes it from the tab order.',
+      control: 'boolean',
+      table: { defaultValue: { summary: 'false' } },
+    },
+    required: {
+      description:
+        'Marks the input as required for native and Base UI `Field` validation.',
+      control: 'boolean',
+      table: { defaultValue: { summary: 'false' } },
+    },
+    readOnly: {
+      description: 'Keeps the value focusable and selectable but not editable.',
+      control: 'boolean',
+      table: { defaultValue: { summary: 'false' } },
+    },
+    'aria-invalid': {
+      description:
+        'Renders the invalid state — a 2px `destructive` outline plus a trailing `triangle-alert` icon.',
+      control: 'boolean',
+      table: { defaultValue: { summary: 'false' } },
+    },
+    className: { table: { disable: true } },
+  },
   decorators: [
-    (Story) => (
+    // `defaultValue` is read once on mount, so key the story on it to remount
+    // when the control changes — otherwise the knob would silently do nothing.
+    (Story, { args }) => (
       <div className="w-64">
-        <Story />
+        <Story key={String(args.defaultValue)} />
       </div>
     ),
   ],
@@ -22,9 +70,15 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
 
-export const Filled: Story = { args: { defaultValue: 'you@nebari.dev' } };
+export const Filled: Story = {
+  args: { defaultValue: 'you@nebari.dev' },
+  parameters: { controls: { include: ['defaultValue'] } },
+};
 
-export const Disabled: Story = { args: { disabled: true } };
+export const Disabled: Story = {
+  args: { disabled: true },
+  parameters: { controls: { include: ['disabled'] } },
+};
 
 /**
  * The error state pairs the 2px `destructive` outline with a trailing
@@ -32,6 +86,7 @@ export const Disabled: Story = { args: { disabled: true } };
  * than color alone (WCAG 1.4.1).
  */
 export const WithError: Story = {
+  parameters: { controls: { include: [] } },
   render: () => (
     <Field>
       <FieldLabel>Email</FieldLabel>
@@ -43,6 +98,7 @@ export const WithError: Story = {
 
 /** Composed in a `Field` — label, description, and control auto-associate. */
 export const WithField: Story = {
+  parameters: { controls: { include: [] } },
   render: () => (
     <Field>
       <FieldLabel>Email</FieldLabel>

--- a/stories/label.stories.tsx
+++ b/stories/label.stories.tsx
@@ -7,6 +7,18 @@ const meta = {
   component: Label,
   parameters: { layout: 'centered' },
   args: { children: 'Label' },
+  argTypes: {
+    children: {
+      description: 'Label text describing the associated control.',
+      control: 'text',
+    },
+    htmlFor: {
+      description:
+        'The `id` of the control this label names. Not needed inside a `Field` — Base UI wires the association through context; use it when pairing a standalone `Label` with an `Input`.',
+      control: 'text',
+    },
+    className: { table: { disable: true } },
+  },
 } satisfies Meta<typeof Label>;
 
 export default meta;
@@ -17,6 +29,7 @@ export const Default: Story = {};
 
 /** Paired with an `Input` via `htmlFor` / `id` for standalone use. */
 export const WithInput: Story = {
+  parameters: { controls: { include: [] } },
   render: () => (
     <div className="flex w-64 flex-col gap-1.5">
       <Label htmlFor="username">Username</Label>

--- a/stories/label.stories.tsx
+++ b/stories/label.stories.tsx
@@ -31,7 +31,7 @@ export const Default: Story = {};
 export const WithInput: Story = {
   args: { children: 'Username' },
   // `htmlFor` stays pinned to the input's `id` — that pairing is the story.
-  parameters: { controls: { include: ['children'] } },
+  parameters: { controls: { include: [] } },
   render: (args) => (
     <div className="flex w-64 flex-col gap-1.5">
       <Label {...args} htmlFor="username" />

--- a/stories/label.stories.tsx
+++ b/stories/label.stories.tsx
@@ -29,10 +29,13 @@ export const Default: Story = {};
 
 /** Paired with an `Input` via `htmlFor` / `id` for standalone use. */
 export const WithInput: Story = {
-  parameters: { controls: { include: [] } },
-  render: () => (
+  args: { children: 'Username' },
+  // `htmlFor` is fixed to the input's `id` — breaking that pairing is the one
+  // thing this story must not allow.
+  parameters: { controls: { include: ['children'] } },
+  render: (args) => (
     <div className="flex w-64 flex-col gap-1.5">
-      <Label htmlFor="username">Username</Label>
+      <Label {...args} htmlFor="username" />
       <Input id="username" placeholder="JaneDoe" />
     </div>
   ),

--- a/stories/label.stories.tsx
+++ b/stories/label.stories.tsx
@@ -30,8 +30,7 @@ export const Default: Story = {};
 /** Paired with an `Input` via `htmlFor` / `id` for standalone use. */
 export const WithInput: Story = {
   args: { children: 'Username' },
-  // `htmlFor` is fixed to the input's `id` — breaking that pairing is the one
-  // thing this story must not allow.
+  // `htmlFor` stays pinned to the input's `id` — that pairing is the story.
   parameters: { controls: { include: ['children'] } },
   render: (args) => (
     <div className="flex w-64 flex-col gap-1.5">

--- a/stories/navigation-menu.stories.tsx
+++ b/stories/navigation-menu.stories.tsx
@@ -114,8 +114,6 @@ export const Default: Story = {
 
 export const SettingsDropdown: Story = {
   name: 'Settings dropdown',
-  // This story shows `NavDropdownMenu`, not `NavLink`, so none of the meta
-  // knobs reach it.
   parameters: { controls: { include: [] } },
   render: () => <SettingsMenu />,
   play: async ({ canvasElement }) => {
@@ -137,7 +135,6 @@ export const SettingsDropdown: Story = {
 
 export const NavItemVariants: Story = {
   name: 'Nav item variants',
-  // Each item fixes the state it demonstrates, plus its own label and href.
   parameters: { controls: { include: [] } },
   render: () => (
     <div className="flex flex-wrap items-center gap-2">

--- a/stories/navigation-menu.stories.tsx
+++ b/stories/navigation-menu.stories.tsx
@@ -22,6 +22,47 @@ const meta = {
       },
     },
   },
+  args: {
+    active: false,
+    children: 'Dashboard',
+    disabled: false,
+    href: '/dashboard',
+  },
+  argTypes: {
+    children: {
+      description: 'The link label.',
+      control: 'text',
+    },
+    href: {
+      description:
+        'Destination for the default anchor. Clicks are suppressed while the link is `active` or `disabled`.',
+      control: 'text',
+    },
+    active: {
+      description:
+        'Marks the link as the current page or section, adding the primary underline indicator.',
+      control: 'boolean',
+      table: { defaultValue: { summary: 'false' } },
+    },
+    disabled: {
+      description:
+        'Removes the link from interaction and applies the muted disabled style.',
+      control: 'boolean',
+      table: { defaultValue: { summary: 'false' } },
+    },
+    icon: {
+      description:
+        'Optional icon rendered before the label, or as the only visible content for an icon-only link.',
+      control: false,
+    },
+    className: { table: { disable: true } },
+    render: {
+      description:
+        'Base UI render-prop composition. Swap the default anchor for a router link while preserving navigation styling and slot attributes.',
+      control: false,
+      table: { defaultValue: { summary: '<a href="/" />' } },
+    },
+  },
 } satisfies Meta<typeof NavLink>;
 
 export default meta;
@@ -67,17 +108,14 @@ function NotificationsMenu() {
   );
 }
 
-export const NavItem: Story = {
-  name: 'Nav item',
-  render: () => (
-    <NavLink href="/dashboard" icon={<Home />}>
-      Dashboard
-    </NavLink>
-  ),
+export const Default: Story = {
+  name: 'Default',
+  render: (args) => <NavLink icon={<Home />} {...args} />,
 };
 
 export const SettingsDropdown: Story = {
   name: 'Settings dropdown',
+  parameters: { controls: { include: [] } },
   render: () => <SettingsMenu />,
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
@@ -98,6 +136,7 @@ export const SettingsDropdown: Story = {
 
 export const NavItemVariants: Story = {
   name: 'Nav item variants',
+  parameters: { controls: { include: [] } },
   render: () => (
     <div className="flex flex-wrap items-center gap-2">
       <NavLink href="/default" icon={<Home />}>
@@ -131,14 +170,37 @@ export const CompleteNavbar: CompleteNavbarStory = {
   },
   argTypes: {
     activeItem: {
+      description:
+        'Story-only toggle. Which primary nav item is marked `active`.',
       control: 'select',
       options: ['Dashboard', 'Projects', 'Reports'],
+      table: { defaultValue: { summary: 'Dashboard' } },
     },
-    showAccount: { control: 'boolean' },
-    showNotifications: { control: 'boolean' },
-    showSettings: { control: 'boolean' },
+    showSettings: {
+      description: 'Story-only toggle for the settings dropdown.',
+      control: 'boolean',
+      table: { defaultValue: { summary: 'true' } },
+    },
+    showNotifications: {
+      description: 'Story-only toggle for the notifications dropdown.',
+      control: 'boolean',
+      table: { defaultValue: { summary: 'true' } },
+    },
+    showAccount: {
+      description: 'Story-only toggle for the account dropdown.',
+      control: 'boolean',
+      table: { defaultValue: { summary: 'true' } },
+    },
   },
   parameters: {
+    controls: {
+      include: [
+        'activeItem',
+        'showSettings',
+        'showNotifications',
+        'showAccount',
+      ],
+    },
     layout: 'fullscreen',
   },
   render: ({ activeItem, showAccount, showNotifications, showSettings }) => (

--- a/stories/navigation-menu.stories.tsx
+++ b/stories/navigation-menu.stories.tsx
@@ -109,7 +109,6 @@ function NotificationsMenu() {
 }
 
 export const Default: Story = {
-  name: 'Default',
   render: (args) => <NavLink icon={<Home />} {...args} />,
 };
 

--- a/stories/navigation-menu.stories.tsx
+++ b/stories/navigation-menu.stories.tsx
@@ -115,7 +115,7 @@ export const Default: Story = {
 export const SettingsDropdown: Story = {
   name: 'Settings dropdown',
   parameters: { controls: { include: [] } },
-  render: () => <SettingsMenu />,
+  render: (_args) => <SettingsMenu />,
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const page = within(canvasElement.ownerDocument.body);
@@ -136,7 +136,7 @@ export const SettingsDropdown: Story = {
 export const NavItemVariants: Story = {
   name: 'Nav item variants',
   parameters: { controls: { include: [] } },
-  render: () => (
+  render: (_args) => (
     <div className="flex flex-wrap items-center gap-2">
       <NavLink href="/default" icon={<Home />}>
         Default

--- a/stories/navigation-menu.stories.tsx
+++ b/stories/navigation-menu.stories.tsx
@@ -115,6 +115,8 @@ export const Default: Story = {
 
 export const SettingsDropdown: Story = {
   name: 'Settings dropdown',
+  // This story shows `NavDropdownMenu`, not `NavLink`, so none of the meta
+  // knobs reach it.
   parameters: { controls: { include: [] } },
   render: () => <SettingsMenu />,
   play: async ({ canvasElement }) => {
@@ -136,6 +138,7 @@ export const SettingsDropdown: Story = {
 
 export const NavItemVariants: Story = {
   name: 'Nav item variants',
+  // Each item fixes the state it demonstrates, plus its own label and href.
   parameters: { controls: { include: [] } },
   render: () => (
     <div className="flex flex-wrap items-center gap-2">

--- a/stories/radio-group.stories.tsx
+++ b/stories/radio-group.stories.tsx
@@ -53,8 +53,7 @@ const meta = {
     },
   },
   args: {
-    // Required `RadioGroupItem` prop. The playground overrides it per option, so
-    // it only satisfies the story arg types.
+    // Required prop; each option overrides it, so this only satisfies the types.
     value: 'option',
     disabled: false,
     orientation: 'vertical',
@@ -140,8 +139,7 @@ export const Default: Story = {
  */
 export const WithDescription: Story = {
   name: 'With description',
-  // Each option carries its own description text, so the `description` knob is
-  // not applicable here — the layout and state knobs are.
+  // Each option carries its own description text, so that knob drops out.
   parameters: { controls: { include: ['variant', 'disabled', 'readOnly'] } },
   render: ({ disabled, readOnly, variant }) => (
     <div className="w-72">
@@ -205,8 +203,6 @@ export const Box: Story = {
  * the whole group can be disabled at once.
  */
 export const Disabled: Story = {
-  // Both groups fix which options are disabled — that contrast is the point —
-  // so `variant` is the knob left to vary.
   parameters: { controls: { include: ['variant'] } },
   render: ({ variant }) => (
     <div className="flex flex-col gap-8">
@@ -277,8 +273,6 @@ export const WithField: Story = {
  * the radios. The cue clears as soon as the user selects an option.
  */
 export const Invalid: Story = {
-  // The field owns `invalid` and the group owns `required`; `variant` is the
-  // one knob that still applies.
   parameters: { controls: { include: ['variant'] } },
   render: ({ variant }) => (
     <Field className="w-80" invalid>

--- a/stories/radio-group.stories.tsx
+++ b/stories/radio-group.stories.tsx
@@ -1,6 +1,16 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import type { ComponentProps } from 'react';
 import { Field, FieldDescription, FieldError, FieldLabel } from '@/ui/field';
 import { RadioGroup, RadioGroupItem } from '@/ui/radio-group';
+
+type RadioGroupStoryArgs = ComponentProps<typeof RadioGroupItem> &
+  Pick<ComponentProps<typeof RadioGroup>, 'orientation'>;
+
+const plans = [
+  { label: 'Starter', value: 'starter' },
+  { label: 'Pro', value: 'pro' },
+  { label: 'Team', value: 'team' },
+];
 
 const meta = {
   title: 'Components/Radio Group',
@@ -14,14 +24,65 @@ const meta = {
       },
     },
   },
-  // Required `RadioGroupItem` prop — each story composes its own group via
-  // `render`, so this only satisfies the story arg types.
-  args: { value: 'option' },
-} satisfies Meta<typeof RadioGroupItem>;
+  args: {
+    // Required `RadioGroupItem` prop. The playground overrides it per option, so
+    // it only satisfies the story arg types.
+    value: 'option',
+    orientation: 'vertical',
+  },
+  argTypes: {
+    variant: {
+      description:
+        'Option layout. `default` is an inline radio; `box` turns each option into a bordered, fully clickable card.',
+      control: 'inline-radio',
+      options: ['default', 'box'],
+      table: { defaultValue: { summary: 'default' } },
+    },
+    orientation: {
+      description:
+        'Set on `RadioGroup`, not the item — stacks options vertically or wraps them in a row.',
+      control: 'inline-radio',
+      options: ['vertical', 'horizontal'],
+      table: { defaultValue: { summary: 'vertical' } },
+    },
+    description: {
+      description:
+        "Supplementary text beneath the option label, exposed as the radio's accessible description.",
+      control: 'text',
+    },
+    disabled: {
+      description:
+        'Disables the option: muted label, a `muted` target fill — `muted-foreground` when the option is selected — and no pointer or keyboard interaction. `RadioGroup` also accepts `disabled` to disable every option at once.',
+      control: 'boolean',
+      table: { defaultValue: { summary: 'false' } },
+    },
+    readOnly: {
+      description: 'Keeps the option focusable but blocks selection changes.',
+      control: 'boolean',
+      table: { defaultValue: { summary: 'false' } },
+    },
+    value: {
+      description:
+        "Identifies the option within its group and is what `RadioGroup`'s value matches against. The playground assigns one per option rather than from a control.",
+      control: false,
+    },
+    children: {
+      description:
+        'The visible and accessible option label. The playground renders one option per plan, so each label is set per item rather than from a control.',
+      control: false,
+    },
+    className: { table: { disable: true } },
+    render: {
+      description:
+        'Base UI render-prop composition. Swap the rendered option element while preserving radio behavior, styling, and slot attributes.',
+      control: false,
+    },
+  },
+} satisfies Meta<RadioGroupStoryArgs>;
 
 export default meta;
 
-type Story = StoryObj<typeof meta>;
+type Story = StoryObj<RadioGroupStoryArgs>;
 
 /**
  * The default option layout. `RadioGroup` provides mutually exclusive
@@ -29,12 +90,18 @@ type Story = StoryObj<typeof meta>;
  * accessible name (here via `aria-label`, or a `Field` label — see below).
  */
 export const Default: Story = {
-  render: () => (
-    <div className="w-72">
-      <RadioGroup aria-label="Plan" defaultValue="pro">
-        <RadioGroupItem value="starter">Starter</RadioGroupItem>
-        <RadioGroupItem value="pro">Pro</RadioGroupItem>
-        <RadioGroupItem value="team">Team</RadioGroupItem>
+  render: ({ orientation, value: _value, ...args }) => (
+    <div className={orientation === 'horizontal' ? 'w-[28rem]' : 'w-72'}>
+      <RadioGroup
+        aria-label="Plan"
+        defaultValue="pro"
+        orientation={orientation}
+      >
+        {plans.map((plan) => (
+          <RadioGroupItem {...args} key={plan.value} value={plan.value}>
+            {plan.label}
+          </RadioGroupItem>
+        ))}
       </RadioGroup>
     </div>
   ),
@@ -46,6 +113,7 @@ export const Default: Story = {
  */
 export const WithDescription: Story = {
   name: 'With description',
+  parameters: { controls: { include: [] } },
   render: () => (
     <div className="w-72">
       <RadioGroup aria-label="Plan" defaultValue="pro">
@@ -74,6 +142,7 @@ export const WithDescription: Story = {
  * wrapping row. The group still owns the single-selection behavior.
  */
 export const Horizontal: Story = {
+  parameters: { controls: { include: [] } },
   render: () => (
     <div className="w-[28rem]">
       <RadioGroup aria-label="Plan" defaultValue="pro" orientation="horizontal">
@@ -90,6 +159,7 @@ export const Horizontal: Story = {
  * Reach for it when options carry more content or need a larger hit target.
  */
 export const Box: Story = {
+  parameters: { controls: { include: [] } },
   render: () => (
     <div className="w-72">
       <RadioGroup aria-label="Plan" defaultValue="pro">
@@ -124,6 +194,7 @@ export const Box: Story = {
  * the whole group can be disabled at once.
  */
 export const Disabled: Story = {
+  parameters: { controls: { include: [] } },
   render: () => (
     <div className="flex flex-col gap-8">
       <div className="flex w-72 flex-col gap-3">
@@ -159,6 +230,7 @@ export const Disabled: Story = {
  */
 export const WithField: Story = {
   name: 'With Field',
+  parameters: { controls: { include: [] } },
   render: () => (
     <Field className="w-80">
       <FieldLabel id="wf-label">Choose a plan</FieldLabel>
@@ -193,6 +265,7 @@ export const WithField: Story = {
  * the radios. The cue clears as soon as the user selects an option.
  */
 export const Invalid: Story = {
+  parameters: { controls: { include: [] } },
   render: () => (
     <Field className="w-80" invalid>
       <FieldLabel id="inv-label">Choose a plan</FieldLabel>

--- a/stories/radio-group.stories.tsx
+++ b/stories/radio-group.stories.tsx
@@ -64,14 +64,14 @@ const meta = {
     variant: {
       description:
         'Option layout. `default` is an inline radio; `box` turns each option into a bordered, fully clickable card.',
-      control: 'inline-radio',
+      control: 'select',
       options: ['default', 'box'],
       table: { defaultValue: { summary: 'default' } },
     },
     orientation: {
       description:
         'Set on `RadioGroup`, not the item — stacks options vertically or wraps them in a row.',
-      control: 'inline-radio',
+      control: 'select',
       options: ['vertical', 'horizontal'],
       table: { defaultValue: { summary: 'vertical' } },
     },
@@ -139,8 +139,7 @@ export const Default: Story = {
  */
 export const WithDescription: Story = {
   name: 'With description',
-  // Each option carries its own description text, so that knob drops out.
-  parameters: { controls: { include: ['variant', 'disabled', 'readOnly'] } },
+  parameters: { controls: { include: [] } },
   render: ({ disabled, readOnly, variant }) => (
     <div className="w-72">
       <RadioGroup aria-label="Plan" defaultValue="pro">
@@ -162,7 +161,7 @@ export const WithDescription: Story = {
 export const Horizontal: Story = {
   args: { orientation: 'horizontal' },
   parameters: {
-    controls: { include: ['orientation', 'variant', 'disabled'] },
+    controls: { include: [] },
   },
   render: ({ disabled, orientation, variant }) => (
     <div className={orientation === 'horizontal' ? 'w-[28rem]' : 'w-72'}>
@@ -183,7 +182,7 @@ export const Horizontal: Story = {
  */
 export const Box: Story = {
   args: { variant: 'box' },
-  parameters: { controls: { include: ['variant', 'disabled', 'readOnly'] } },
+  parameters: { controls: { include: [] } },
   render: ({ disabled, readOnly, variant }) => (
     <div className="w-72">
       <RadioGroup aria-label="Plan" defaultValue="pro">
@@ -203,7 +202,7 @@ export const Box: Story = {
  * the whole group can be disabled at once.
  */
 export const Disabled: Story = {
-  parameters: { controls: { include: ['variant'] } },
+  parameters: { controls: { include: [] } },
   render: ({ variant }) => (
     <div className="flex flex-col gap-8">
       <div className="flex w-72 flex-col gap-3">
@@ -240,7 +239,7 @@ export const Disabled: Story = {
  * optional description, and the radio group — all associated for accessibility.
  */
 export const WithField: Story = {
-  parameters: { controls: { include: ['variant', 'disabled'] } },
+  parameters: { controls: { include: [] } },
   render: ({ disabled, variant }) => (
     <Field className="w-80">
       <FieldLabel id="wf-label">Choose a plan</FieldLabel>
@@ -273,7 +272,7 @@ export const WithField: Story = {
  * the radios. The cue clears as soon as the user selects an option.
  */
 export const Invalid: Story = {
-  parameters: { controls: { include: ['variant'] } },
+  parameters: { controls: { include: [] } },
   render: ({ variant }) => (
     <Field className="w-80" invalid>
       <FieldLabel id="inv-label">Choose a plan</FieldLabel>

--- a/stories/radio-group.stories.tsx
+++ b/stories/radio-group.stories.tsx
@@ -28,7 +28,10 @@ const meta = {
     // Required `RadioGroupItem` prop. The playground overrides it per option, so
     // it only satisfies the story arg types.
     value: 'option',
+    disabled: false,
     orientation: 'vertical',
+    readOnly: false,
+    variant: 'default',
   },
   argTypes: {
     variant: {
@@ -113,23 +116,37 @@ export const Default: Story = {
  */
 export const WithDescription: Story = {
   name: 'With description',
-  parameters: { controls: { include: [] } },
-  render: () => (
+  // Each option carries its own description text, so the `description` knob is
+  // not applicable here — the layout and state knobs are.
+  parameters: { controls: { include: ['variant', 'disabled', 'readOnly'] } },
+  render: ({ disabled, readOnly, variant }) => (
     <div className="w-72">
       <RadioGroup aria-label="Plan" defaultValue="pro">
         <RadioGroupItem
           description="For individuals getting started."
+          disabled={disabled}
+          readOnly={readOnly}
           value="starter"
+          variant={variant}
         >
           Starter
         </RadioGroupItem>
         <RadioGroupItem
           description="For growing teams that need more."
+          disabled={disabled}
+          readOnly={readOnly}
           value="pro"
+          variant={variant}
         >
           Pro
         </RadioGroupItem>
-        <RadioGroupItem description="For organizations at scale." value="team">
+        <RadioGroupItem
+          description="For organizations at scale."
+          disabled={disabled}
+          readOnly={readOnly}
+          value="team"
+          variant={variant}
+        >
           Team
         </RadioGroupItem>
       </RadioGroup>
@@ -142,13 +159,27 @@ export const WithDescription: Story = {
  * wrapping row. The group still owns the single-selection behavior.
  */
 export const Horizontal: Story = {
-  parameters: { controls: { include: [] } },
-  render: () => (
-    <div className="w-[28rem]">
-      <RadioGroup aria-label="Plan" defaultValue="pro" orientation="horizontal">
-        <RadioGroupItem value="starter">Starter</RadioGroupItem>
-        <RadioGroupItem value="pro">Pro</RadioGroupItem>
-        <RadioGroupItem value="team">Team</RadioGroupItem>
+  args: { orientation: 'horizontal' },
+  parameters: {
+    controls: { include: ['orientation', 'variant', 'disabled'] },
+  },
+  render: ({ disabled, orientation, variant }) => (
+    <div className={orientation === 'horizontal' ? 'w-[28rem]' : 'w-72'}>
+      <RadioGroup
+        aria-label="Plan"
+        defaultValue="pro"
+        orientation={orientation}
+      >
+        {plans.map((plan) => (
+          <RadioGroupItem
+            disabled={disabled}
+            key={plan.value}
+            value={plan.value}
+            variant={variant}
+          >
+            {plan.label}
+          </RadioGroupItem>
+        ))}
       </RadioGroup>
     </div>
   ),
@@ -159,28 +190,35 @@ export const Horizontal: Story = {
  * Reach for it when options carry more content or need a larger hit target.
  */
 export const Box: Story = {
-  parameters: { controls: { include: [] } },
-  render: () => (
+  args: { variant: 'box' },
+  parameters: { controls: { include: ['variant', 'disabled', 'readOnly'] } },
+  render: ({ disabled, readOnly, variant }) => (
     <div className="w-72">
       <RadioGroup aria-label="Plan" defaultValue="pro">
         <RadioGroupItem
           description="For individuals getting started."
+          disabled={disabled}
+          readOnly={readOnly}
           value="starter"
-          variant="box"
+          variant={variant}
         >
           Starter
         </RadioGroupItem>
         <RadioGroupItem
           description="For growing teams that need more."
+          disabled={disabled}
+          readOnly={readOnly}
           value="pro"
-          variant="box"
+          variant={variant}
         >
           Pro
         </RadioGroupItem>
         <RadioGroupItem
           description="For organizations at scale."
+          disabled={disabled}
+          readOnly={readOnly}
           value="team"
-          variant="box"
+          variant={variant}
         >
           Team
         </RadioGroupItem>
@@ -194,17 +232,23 @@ export const Box: Story = {
  * the whole group can be disabled at once.
  */
 export const Disabled: Story = {
-  parameters: { controls: { include: [] } },
-  render: () => (
+  // Both groups fix which options are disabled — that contrast is the point —
+  // so `variant` is the knob left to vary.
+  parameters: { controls: { include: ['variant'] } },
+  render: ({ variant }) => (
     <div className="flex flex-col gap-8">
       <div className="flex w-72 flex-col gap-3">
         <p className="font-medium text-muted-foreground text-xs">
           One option disabled
         </p>
         <RadioGroup aria-label="Plan" defaultValue="pro">
-          <RadioGroupItem value="starter">Starter</RadioGroupItem>
-          <RadioGroupItem value="pro">Pro</RadioGroupItem>
-          <RadioGroupItem disabled value="team">
+          <RadioGroupItem value="starter" variant={variant}>
+            Starter
+          </RadioGroupItem>
+          <RadioGroupItem value="pro" variant={variant}>
+            Pro
+          </RadioGroupItem>
+          <RadioGroupItem disabled value="team" variant={variant}>
             Team (coming soon)
           </RadioGroupItem>
         </RadioGroup>
@@ -215,9 +259,15 @@ export const Disabled: Story = {
           Entire group disabled
         </p>
         <RadioGroup aria-label="Plan" defaultValue="pro" disabled>
-          <RadioGroupItem value="starter">Starter</RadioGroupItem>
-          <RadioGroupItem value="pro">Pro</RadioGroupItem>
-          <RadioGroupItem value="team">Team</RadioGroupItem>
+          {plans.map((plan) => (
+            <RadioGroupItem
+              key={plan.value}
+              value={plan.value}
+              variant={variant}
+            >
+              {plan.label}
+            </RadioGroupItem>
+          ))}
         </RadioGroup>
       </div>
     </div>
@@ -230,8 +280,8 @@ export const Disabled: Story = {
  */
 export const WithField: Story = {
   name: 'With Field',
-  parameters: { controls: { include: [] } },
-  render: () => (
+  parameters: { controls: { include: ['variant', 'disabled'] } },
+  render: ({ disabled, variant }) => (
     <Field className="w-80">
       <FieldLabel id="wf-label">Choose a plan</FieldLabel>
       <FieldDescription id="wf-desc">
@@ -242,9 +292,16 @@ export const WithField: Story = {
         aria-labelledby="wf-label"
         defaultValue="pro"
       >
-        <RadioGroupItem value="starter">Starter</RadioGroupItem>
-        <RadioGroupItem value="pro">Pro</RadioGroupItem>
-        <RadioGroupItem value="team">Team</RadioGroupItem>
+        {plans.map((plan) => (
+          <RadioGroupItem
+            disabled={disabled}
+            key={plan.value}
+            value={plan.value}
+            variant={variant}
+          >
+            {plan.label}
+          </RadioGroupItem>
+        ))}
       </RadioGroup>
     </Field>
   ),
@@ -265,8 +322,10 @@ export const WithField: Story = {
  * the radios. The cue clears as soon as the user selects an option.
  */
 export const Invalid: Story = {
-  parameters: { controls: { include: [] } },
-  render: () => (
+  // The field owns `invalid` and the group owns `required`; `variant` is the
+  // one knob that still applies.
+  parameters: { controls: { include: ['variant'] } },
+  render: ({ variant }) => (
     <Field className="w-80" invalid>
       <FieldLabel id="inv-label">Choose a plan</FieldLabel>
       <RadioGroup
@@ -274,9 +333,11 @@ export const Invalid: Story = {
         aria-labelledby="inv-label"
         required
       >
-        <RadioGroupItem value="starter">Starter</RadioGroupItem>
-        <RadioGroupItem value="pro">Pro</RadioGroupItem>
-        <RadioGroupItem value="team">Team</RadioGroupItem>
+        {plans.map((plan) => (
+          <RadioGroupItem key={plan.value} value={plan.value} variant={variant}>
+            {plan.label}
+          </RadioGroupItem>
+        ))}
       </RadioGroup>
       <FieldError id="inv-error" match>
         Please select a plan to continue.

--- a/stories/radio-group.stories.tsx
+++ b/stories/radio-group.stories.tsx
@@ -7,10 +7,38 @@ type RadioGroupStoryArgs = ComponentProps<typeof RadioGroupItem> &
   Pick<ComponentProps<typeof RadioGroup>, 'orientation'>;
 
 const plans = [
-  { label: 'Starter', value: 'starter' },
-  { label: 'Pro', value: 'pro' },
-  { label: 'Team', value: 'team' },
+  {
+    label: 'Starter',
+    value: 'starter',
+    description: 'For individuals getting started.',
+  },
+  {
+    label: 'Pro',
+    value: 'pro',
+    description: 'For growing teams that need more.',
+  },
+  { label: 'Team', value: 'team', description: 'For organizations at scale.' },
 ];
+
+/** The three plan options, so each story only supplies the knobs it exposes. */
+function PlanOptions({
+  showDescriptions = false,
+  ...itemProps
+}: Omit<
+  ComponentProps<typeof RadioGroupItem>,
+  'children' | 'description' | 'value'
+> & { showDescriptions?: boolean }) {
+  return plans.map((plan) => (
+    <RadioGroupItem
+      {...itemProps}
+      description={showDescriptions ? plan.description : undefined}
+      key={plan.value}
+      value={plan.value}
+    >
+      {plan.label}
+    </RadioGroupItem>
+  ));
+}
 
 const meta = {
   title: 'Components/Radio Group',
@@ -100,11 +128,7 @@ export const Default: Story = {
         defaultValue="pro"
         orientation={orientation}
       >
-        {plans.map((plan) => (
-          <RadioGroupItem {...args} key={plan.value} value={plan.value}>
-            {plan.label}
-          </RadioGroupItem>
-        ))}
+        <PlanOptions {...args} />
       </RadioGroup>
     </div>
   ),
@@ -122,33 +146,12 @@ export const WithDescription: Story = {
   render: ({ disabled, readOnly, variant }) => (
     <div className="w-72">
       <RadioGroup aria-label="Plan" defaultValue="pro">
-        <RadioGroupItem
-          description="For individuals getting started."
+        <PlanOptions
           disabled={disabled}
           readOnly={readOnly}
-          value="starter"
+          showDescriptions
           variant={variant}
-        >
-          Starter
-        </RadioGroupItem>
-        <RadioGroupItem
-          description="For growing teams that need more."
-          disabled={disabled}
-          readOnly={readOnly}
-          value="pro"
-          variant={variant}
-        >
-          Pro
-        </RadioGroupItem>
-        <RadioGroupItem
-          description="For organizations at scale."
-          disabled={disabled}
-          readOnly={readOnly}
-          value="team"
-          variant={variant}
-        >
-          Team
-        </RadioGroupItem>
+        />
       </RadioGroup>
     </div>
   ),
@@ -170,16 +173,7 @@ export const Horizontal: Story = {
         defaultValue="pro"
         orientation={orientation}
       >
-        {plans.map((plan) => (
-          <RadioGroupItem
-            disabled={disabled}
-            key={plan.value}
-            value={plan.value}
-            variant={variant}
-          >
-            {plan.label}
-          </RadioGroupItem>
-        ))}
+        <PlanOptions disabled={disabled} variant={variant} />
       </RadioGroup>
     </div>
   ),
@@ -195,33 +189,12 @@ export const Box: Story = {
   render: ({ disabled, readOnly, variant }) => (
     <div className="w-72">
       <RadioGroup aria-label="Plan" defaultValue="pro">
-        <RadioGroupItem
-          description="For individuals getting started."
+        <PlanOptions
           disabled={disabled}
           readOnly={readOnly}
-          value="starter"
+          showDescriptions
           variant={variant}
-        >
-          Starter
-        </RadioGroupItem>
-        <RadioGroupItem
-          description="For growing teams that need more."
-          disabled={disabled}
-          readOnly={readOnly}
-          value="pro"
-          variant={variant}
-        >
-          Pro
-        </RadioGroupItem>
-        <RadioGroupItem
-          description="For organizations at scale."
-          disabled={disabled}
-          readOnly={readOnly}
-          value="team"
-          variant={variant}
-        >
-          Team
-        </RadioGroupItem>
+        />
       </RadioGroup>
     </div>
   ),
@@ -259,15 +232,7 @@ export const Disabled: Story = {
           Entire group disabled
         </p>
         <RadioGroup aria-label="Plan" defaultValue="pro" disabled>
-          {plans.map((plan) => (
-            <RadioGroupItem
-              key={plan.value}
-              value={plan.value}
-              variant={variant}
-            >
-              {plan.label}
-            </RadioGroupItem>
-          ))}
+          <PlanOptions variant={variant} />
         </RadioGroup>
       </div>
     </div>
@@ -279,7 +244,6 @@ export const Disabled: Story = {
  * optional description, and the radio group — all associated for accessibility.
  */
 export const WithField: Story = {
-  name: 'With Field',
   parameters: { controls: { include: ['variant', 'disabled'] } },
   render: ({ disabled, variant }) => (
     <Field className="w-80">
@@ -292,16 +256,7 @@ export const WithField: Story = {
         aria-labelledby="wf-label"
         defaultValue="pro"
       >
-        {plans.map((plan) => (
-          <RadioGroupItem
-            disabled={disabled}
-            key={plan.value}
-            value={plan.value}
-            variant={variant}
-          >
-            {plan.label}
-          </RadioGroupItem>
-        ))}
+        <PlanOptions disabled={disabled} variant={variant} />
       </RadioGroup>
     </Field>
   ),
@@ -333,11 +288,7 @@ export const Invalid: Story = {
         aria-labelledby="inv-label"
         required
       >
-        {plans.map((plan) => (
-          <RadioGroupItem key={plan.value} value={plan.value} variant={variant}>
-            {plan.label}
-          </RadioGroupItem>
-        ))}
+        <PlanOptions variant={variant} />
       </RadioGroup>
       <FieldError id="inv-error" match>
         Please select a plan to continue.

--- a/stories/select.stories.tsx
+++ b/stories/select.stories.tsx
@@ -145,6 +145,7 @@ const meta = {
   args: {
     align: 'center',
     alignItemWithTrigger: false,
+    disabled: false,
     invalid: false,
     side: 'bottom',
     sideOffset: 0,
@@ -253,12 +254,28 @@ export const Default: Story = {
 };
 
 export const Groups: Story = {
-  parameters: { controls: { include: [] } },
-  render: () => (
+  // The item composition is the subject; the popup positioning knobs still
+  // apply. `disabled` is left out — it would hide what the story shows.
+  parameters: {
+    controls: {
+      include: ['side', 'align', 'sideOffset', 'alignItemWithTrigger'],
+    },
+  },
+  render: ({
+    align,
+    alignItemWithTrigger,
+    invalid,
+    side,
+    sideOffset,
+    ...triggerProps
+  }) => (
     <SelectPreview
+      contentProps={{ align, alignItemWithTrigger, side, sideOffset }}
+      invalid={invalid}
       label="Deployment target"
       options={[...frameworks, ...regions]}
       placeholder="Select a target"
+      triggerProps={triggerProps}
     >
       <SelectGroup>
         <SelectLabel>Frameworks</SelectLabel>
@@ -282,37 +299,73 @@ export const Groups: Story = {
 };
 
 export const Scrollable: Story = {
-  parameters: { controls: { include: [] } },
-  render: () => (
+  // `max-h-56` on the popup is what makes it scroll, so only the positioning
+  // knobs are live here.
+  parameters: {
+    controls: {
+      include: ['side', 'align', 'sideOffset', 'alignItemWithTrigger'],
+    },
+  },
+  render: ({
+    align,
+    alignItemWithTrigger,
+    invalid,
+    side,
+    sideOffset,
+    ...triggerProps
+  }) => (
     <SelectPreview
       contentClassName="max-h-56"
+      contentProps={{ align, alignItemWithTrigger, side, sideOffset }}
+      invalid={invalid}
       label="Timezone"
       options={timezones}
       placeholder="Select a timezone"
+      triggerProps={triggerProps}
     />
   ),
 };
 
 export const Disabled: Story = {
-  parameters: { controls: { include: [] } },
-  render: () => (
+  args: { disabled: true },
+  parameters: { controls: { include: ['disabled'] } },
+  render: ({
+    align,
+    alignItemWithTrigger,
+    invalid,
+    side,
+    sideOffset,
+    ...triggerProps
+  }) => (
     <SelectPreview
+      contentProps={{ align, alignItemWithTrigger, side, sideOffset }}
       helperText="This select is unavailable."
+      invalid={invalid}
       label="Framework"
       placeholder="Select a framework"
-      triggerProps={{ disabled: true }}
+      triggerProps={triggerProps}
     />
   ),
 };
 
 export const Invalid: Story = {
-  parameters: { controls: { include: [] } },
-  render: () => (
+  args: { invalid: true },
+  parameters: { controls: { include: ['invalid'] } },
+  render: ({
+    align,
+    alignItemWithTrigger,
+    invalid,
+    side,
+    sideOffset,
+    ...triggerProps
+  }) => (
     <SelectPreview
+      contentProps={{ align, alignItemWithTrigger, side, sideOffset }}
       helperText="Please select a framework."
-      invalid
+      invalid={invalid}
       label="Framework"
       placeholder="Select a framework"
+      triggerProps={triggerProps}
     />
   ),
 };

--- a/stories/select.stories.tsx
+++ b/stories/select.stories.tsx
@@ -51,17 +51,22 @@ const timezones = [
 type SelectTriggerProps = ComponentProps<typeof SelectTrigger>;
 type SelectContentProps = ComponentProps<typeof SelectContent>;
 
+type SelectStoryArgs = SelectTriggerProps &
+  Pick<
+    SelectContentProps,
+    'align' | 'alignItemWithTrigger' | 'side' | 'sideOffset'
+  > & {
+    invalid?: boolean;
+  };
+
 interface SelectPreviewProps {
+  args: SelectStoryArgs;
   label: string;
   placeholder: string;
   options?: readonly SelectOption[];
-  defaultValue?: string;
   children?: ReactNode;
   helperText?: ReactNode;
-  invalid?: boolean;
   contentClassName?: string;
-  contentProps?: Omit<SelectContentProps, 'children'>;
-  triggerProps?: Omit<SelectTriggerProps, 'children'>;
 }
 
 function findOptionLabel(
@@ -72,31 +77,38 @@ function findOptionLabel(
   return options.find((option) => option.value === value)?.label ?? placeholder;
 }
 
+/**
+ * Splits the flat story args across the two components they belong to — the
+ * positioning knobs onto `SelectContent`, everything else onto `SelectTrigger`.
+ */
 function SelectPreview({
+  args: { align, alignItemWithTrigger, invalid, side, sideOffset, ...trigger },
   label,
   placeholder,
   options = frameworks,
-  defaultValue,
   children,
   helperText = 'Select one option.',
-  invalid = false,
   contentClassName,
-  contentProps,
-  triggerProps,
 }: SelectPreviewProps) {
   return (
-    <Field className="w-64" disabled={triggerProps?.disabled} invalid={invalid}>
+    <Field className="w-64" disabled={trigger.disabled} invalid={invalid}>
       <FieldLabel>{label}</FieldLabel>
-      <Select defaultValue={defaultValue} items={options} modal={false}>
+      <Select items={options} modal={false}>
         <SelectTrigger
-          {...triggerProps}
-          aria-invalid={invalid || triggerProps?.['aria-invalid']}
+          {...trigger}
+          aria-invalid={invalid || trigger['aria-invalid']}
         >
           <SelectValue>
             {(value) => findOptionLabel(options, value, placeholder)}
           </SelectValue>
         </SelectTrigger>
-        <SelectContent {...contentProps} className={contentClassName}>
+        <SelectContent
+          align={align}
+          alignItemWithTrigger={alignItemWithTrigger}
+          className={contentClassName}
+          side={side}
+          sideOffset={sideOffset}
+        >
           {children ??
             options.map((option) => (
               <SelectItem
@@ -121,14 +133,6 @@ function SelectPreview({
     </Field>
   );
 }
-
-type SelectStoryArgs = SelectTriggerProps &
-  Pick<
-    SelectContentProps,
-    'align' | 'alignItemWithTrigger' | 'side' | 'sideOffset'
-  > & {
-    invalid?: boolean;
-  };
 
 const meta = {
   title: 'Components/Select',
@@ -208,20 +212,11 @@ export default meta;
 type Story = StoryObj<SelectStoryArgs>;
 
 export const Default: Story = {
-  render: ({
-    align,
-    alignItemWithTrigger,
-    invalid,
-    side,
-    sideOffset,
-    ...triggerProps
-  }) => (
+  render: (args) => (
     <SelectPreview
-      contentProps={{ align, alignItemWithTrigger, side, sideOffset }}
-      invalid={invalid}
+      args={args}
       label="Framework"
       placeholder="Select a framework"
-      triggerProps={triggerProps}
     />
   ),
   play: async ({ canvasElement }) => {
@@ -261,21 +256,12 @@ export const Groups: Story = {
       include: ['side', 'align', 'sideOffset', 'alignItemWithTrigger'],
     },
   },
-  render: ({
-    align,
-    alignItemWithTrigger,
-    invalid,
-    side,
-    sideOffset,
-    ...triggerProps
-  }) => (
+  render: (args) => (
     <SelectPreview
-      contentProps={{ align, alignItemWithTrigger, side, sideOffset }}
-      invalid={invalid}
+      args={args}
       label="Deployment target"
       options={[...frameworks, ...regions]}
       placeholder="Select a target"
-      triggerProps={triggerProps}
     >
       <SelectGroup>
         <SelectLabel>Frameworks</SelectLabel>
@@ -306,22 +292,13 @@ export const Scrollable: Story = {
       include: ['side', 'align', 'sideOffset', 'alignItemWithTrigger'],
     },
   },
-  render: ({
-    align,
-    alignItemWithTrigger,
-    invalid,
-    side,
-    sideOffset,
-    ...triggerProps
-  }) => (
+  render: (args) => (
     <SelectPreview
+      args={args}
       contentClassName="max-h-56"
-      contentProps={{ align, alignItemWithTrigger, side, sideOffset }}
-      invalid={invalid}
       label="Timezone"
       options={timezones}
       placeholder="Select a timezone"
-      triggerProps={triggerProps}
     />
   ),
 };
@@ -329,21 +306,12 @@ export const Scrollable: Story = {
 export const Disabled: Story = {
   args: { disabled: true },
   parameters: { controls: { include: ['disabled'] } },
-  render: ({
-    align,
-    alignItemWithTrigger,
-    invalid,
-    side,
-    sideOffset,
-    ...triggerProps
-  }) => (
+  render: (args) => (
     <SelectPreview
-      contentProps={{ align, alignItemWithTrigger, side, sideOffset }}
+      args={args}
       helperText="This select is unavailable."
-      invalid={invalid}
       label="Framework"
       placeholder="Select a framework"
-      triggerProps={triggerProps}
     />
   ),
 };
@@ -351,21 +319,12 @@ export const Disabled: Story = {
 export const Invalid: Story = {
   args: { invalid: true },
   parameters: { controls: { include: ['invalid'] } },
-  render: ({
-    align,
-    alignItemWithTrigger,
-    invalid,
-    side,
-    sideOffset,
-    ...triggerProps
-  }) => (
+  render: (args) => (
     <SelectPreview
-      contentProps={{ align, alignItemWithTrigger, side, sideOffset }}
+      args={args}
       helperText="Please select a framework."
-      invalid={invalid}
       label="Framework"
       placeholder="Select a framework"
-      triggerProps={triggerProps}
     />
   ),
 };

--- a/stories/select.stories.tsx
+++ b/stories/select.stories.tsx
@@ -249,8 +249,7 @@ export const Default: Story = {
 };
 
 export const Groups: Story = {
-  // The item composition is the subject; the popup positioning knobs still
-  // apply. `disabled` is left out — it would hide what the story shows.
+  // `disabled` is left out — it would hide what the story shows.
   parameters: {
     controls: {
       include: ['side', 'align', 'sideOffset', 'alignItemWithTrigger'],
@@ -285,8 +284,6 @@ export const Groups: Story = {
 };
 
 export const Scrollable: Story = {
-  // `max-h-56` on the popup is what makes it scroll, so only the positioning
-  // knobs are live here.
   parameters: {
     controls: {
       include: ['side', 'align', 'sideOffset', 'alignItemWithTrigger'],

--- a/stories/select.stories.tsx
+++ b/stories/select.stories.tsx
@@ -49,6 +49,7 @@ const timezones = [
 ] satisfies SelectOption[];
 
 type SelectTriggerProps = ComponentProps<typeof SelectTrigger>;
+type SelectContentProps = ComponentProps<typeof SelectContent>;
 
 interface SelectPreviewProps {
   label: string;
@@ -59,6 +60,7 @@ interface SelectPreviewProps {
   helperText?: ReactNode;
   invalid?: boolean;
   contentClassName?: string;
+  contentProps?: Omit<SelectContentProps, 'children'>;
   triggerProps?: Omit<SelectTriggerProps, 'children'>;
 }
 
@@ -79,6 +81,7 @@ function SelectPreview({
   helperText = 'Select one option.',
   invalid = false,
   contentClassName,
+  contentProps,
   triggerProps,
 }: SelectPreviewProps) {
   return (
@@ -93,7 +96,7 @@ function SelectPreview({
             {(value) => findOptionLabel(options, value, placeholder)}
           </SelectValue>
         </SelectTrigger>
-        <SelectContent className={contentClassName}>
+        <SelectContent {...contentProps} className={contentClassName}>
           {children ??
             options.map((option) => (
               <SelectItem
@@ -119,6 +122,14 @@ function SelectPreview({
   );
 }
 
+type SelectStoryArgs = SelectTriggerProps &
+  Pick<
+    SelectContentProps,
+    'align' | 'alignItemWithTrigger' | 'side' | 'sideOffset'
+  > & {
+    invalid?: boolean;
+  };
+
 const meta = {
   title: 'Components/Select',
   component: SelectTrigger,
@@ -131,21 +142,85 @@ const meta = {
       },
     },
   },
-  argTypes: {
-    disabled: { control: 'boolean' },
+  args: {
+    align: 'center',
+    alignItemWithTrigger: false,
+    invalid: false,
+    side: 'bottom',
+    sideOffset: 0,
   },
-} satisfies Meta<typeof SelectTrigger>;
+  argTypes: {
+    disabled: {
+      description:
+        'Disables the trigger — muted fill, no pointer or keyboard interaction, and the popup can no longer be opened.',
+      control: 'boolean',
+      table: { defaultValue: { summary: 'false' } },
+    },
+    invalid: {
+      description:
+        'Story-only toggle. Marks the surrounding `Field` invalid and sets `aria-invalid` on the trigger, swapping the border and ring to `destructive` and the description for a `FieldError`.',
+      control: 'boolean',
+      table: { defaultValue: { summary: 'false' } },
+    },
+    side: {
+      description:
+        'Set on `SelectContent` — which side of the trigger the popup is positioned against.',
+      control: 'select',
+      options: ['top', 'right', 'bottom', 'left'],
+      table: { defaultValue: { summary: 'bottom' } },
+    },
+    align: {
+      description:
+        'Set on `SelectContent` — how the popup aligns along the trigger on the chosen side.',
+      control: 'inline-radio',
+      options: ['start', 'center', 'end'],
+      table: { defaultValue: { summary: 'center' } },
+    },
+    sideOffset: {
+      description:
+        'Set on `SelectContent` — gap in pixels between the trigger and the popup.',
+      control: { type: 'number', min: 0, max: 24, step: 1 },
+      table: { defaultValue: { summary: '0' } },
+    },
+    alignItemWithTrigger: {
+      description:
+        'Set on `SelectContent`. When enabled the popup overlays the trigger so the selected item sits on top of it, instead of opening below.',
+      control: 'boolean',
+      table: { defaultValue: { summary: 'false' } },
+    },
+    children: {
+      description:
+        'Trigger content — a `SelectValue`, whose render prop receives the selected value so it can resolve the matching option label.',
+      control: false,
+    },
+    className: { table: { disable: true } },
+    render: {
+      description:
+        'Base UI render-prop composition. Swap the trigger element while preserving select behavior, styling, and slot attributes.',
+      control: false,
+    },
+  },
+} satisfies Meta<SelectStoryArgs>;
 
 export default meta;
 
-type Story = StoryObj<typeof meta>;
+type Story = StoryObj<SelectStoryArgs>;
 
 export const Default: Story = {
-  render: (args) => (
+  render: ({
+    align,
+    alignItemWithTrigger,
+    invalid,
+    side,
+    sideOffset,
+    ...triggerProps
+  }) => (
     <SelectPreview
+      contentProps={{ align, alignItemWithTrigger, side, sideOffset }}
+      invalid={invalid}
       label="Framework"
       placeholder="Select a framework"
-      triggerProps={args}
+      triggerProps={triggerProps}
     />
   ),
   play: async ({ canvasElement }) => {
@@ -178,6 +253,7 @@ export const Default: Story = {
 };
 
 export const Groups: Story = {
+  parameters: { controls: { include: [] } },
   render: () => (
     <SelectPreview
       label="Deployment target"
@@ -206,6 +282,7 @@ export const Groups: Story = {
 };
 
 export const Scrollable: Story = {
+  parameters: { controls: { include: [] } },
   render: () => (
     <SelectPreview
       contentClassName="max-h-56"
@@ -217,6 +294,7 @@ export const Scrollable: Story = {
 };
 
 export const Disabled: Story = {
+  parameters: { controls: { include: [] } },
   render: () => (
     <SelectPreview
       helperText="This select is unavailable."
@@ -228,6 +306,7 @@ export const Disabled: Story = {
 };
 
 export const Invalid: Story = {
+  parameters: { controls: { include: [] } },
   render: () => (
     <SelectPreview
       helperText="Please select a framework."

--- a/stories/select.stories.tsx
+++ b/stories/select.stories.tsx
@@ -177,7 +177,7 @@ const meta = {
     align: {
       description:
         'Set on `SelectContent` — how the popup aligns along the trigger on the chosen side.',
-      control: 'inline-radio',
+      control: 'select',
       options: ['start', 'center', 'end'],
       table: { defaultValue: { summary: 'center' } },
     },
@@ -252,7 +252,7 @@ export const Groups: Story = {
   // `disabled` is left out — it would hide what the story shows.
   parameters: {
     controls: {
-      include: ['side', 'align', 'sideOffset', 'alignItemWithTrigger'],
+      include: [],
     },
   },
   render: (args) => (
@@ -286,7 +286,7 @@ export const Groups: Story = {
 export const Scrollable: Story = {
   parameters: {
     controls: {
-      include: ['side', 'align', 'sideOffset', 'alignItemWithTrigger'],
+      include: [],
     },
   },
   render: (args) => (
@@ -302,7 +302,7 @@ export const Scrollable: Story = {
 
 export const Disabled: Story = {
   args: { disabled: true },
-  parameters: { controls: { include: ['disabled'] } },
+  parameters: { controls: { include: [] } },
   render: (args) => (
     <SelectPreview
       args={args}
@@ -315,7 +315,7 @@ export const Disabled: Story = {
 
 export const Invalid: Story = {
   args: { invalid: true },
-  parameters: { controls: { include: ['invalid'] } },
+  parameters: { controls: { include: [] } },
   render: (args) => (
     <SelectPreview
       args={args}

--- a/stories/slider.stories.tsx
+++ b/stories/slider.stories.tsx
@@ -52,25 +52,62 @@ const meta = {
     step: 1,
   },
   argTypes: {
-    defaultValue: { control: 'number' },
-    disabled: { control: 'boolean' },
-    getThumbAriaLabel: { table: { disable: true } },
-    getThumbAriaValueText: { table: { disable: true } },
-    max: { control: 'number' },
-    min: { control: 'number' },
-    onValueChange: { table: { disable: true } },
-    onValueCommitted: { table: { disable: true } },
+    defaultValue: {
+      control: 'number',
+      description:
+        'Initial value when the slider is uncontrolled. Pass an array for a range or multi-thumb slider.',
+      table: { defaultValue: { summary: '0' } },
+    },
+    min: {
+      control: 'number',
+      description: 'Lower bound of the range.',
+      table: { defaultValue: { summary: '0' } },
+    },
+    max: {
+      control: 'number',
+      description: 'Upper bound of the range.',
+      table: { defaultValue: { summary: '100' } },
+    },
+    step: {
+      control: 'number',
+      description:
+        'Granularity the value must adhere to. Arrow keys move by one step.',
+      table: { defaultValue: { summary: '1' } },
+    },
+    minStepsBetweenValues: {
+      description:
+        'Minimum number of steps that must separate two thumbs. Only applies to a range or multi-thumb slider, so it is a docs-only row here — the playground is single-thumb. See the `Range` and `Multiple Thumbs` stories.',
+      control: false,
+      table: { defaultValue: { summary: '0' } },
+    },
     orientation: {
       control: 'inline-radio',
+      description:
+        'Track direction. `vertical` fills from the bottom up and needs a fixed-height wrapper.',
       options: ['horizontal', 'vertical'],
       table: { defaultValue: { summary: 'horizontal' } },
     },
     showValueTooltip: {
       control: 'boolean',
+      description:
+        'Shows the current value in a tooltip above the thumb while dragging or focused.',
       table: { defaultValue: { summary: 'true' } },
     },
-    step: { control: 'number' },
-    value: { table: { disable: true } },
+    disabled: {
+      control: 'boolean',
+      description:
+        'Mutes the track and thumb and blocks pointer and keyboard interaction — the value stays readable.',
+      table: { defaultValue: { summary: 'false' } },
+    },
+    getThumbAriaLabel: { table: { disable: true } },
+    getThumbAriaValueText: { table: { disable: true } },
+    onValueChange: { table: { disable: true } },
+    onValueCommitted: { table: { disable: true } },
+    value: {
+      description:
+        'Controlled value. Pair it with `onValueChange`; left as a docs-only row here so the playground stays interactive.',
+      control: false,
+    },
   },
 } satisfies Meta<typeof Slider>;
 
@@ -80,15 +117,22 @@ type Story = StoryObj<typeof meta>;
 
 /** The default slider selects a single value from a bounded range. */
 export const Default: Story = {
+  // `defaultValue` is read once on mount, so key the slider on it to remount
+  // when the control changes.
   render: (args) => (
     <div className={args.orientation === 'vertical' ? 'h-52' : 'w-80'}>
-      <Slider {...args} getThumbAriaLabel={() => 'Resource limit'} />
+      <Slider
+        key={String(args.defaultValue)}
+        {...args}
+        getThumbAriaLabel={() => 'Resource limit'}
+      />
     </div>
   ),
 };
 
 /** Use an array with two values for a range slider. */
 export const Range: Story = {
+  parameters: { controls: { include: [] } },
   render: () => (
     <div className="w-80">
       <Slider
@@ -105,6 +149,7 @@ export const Range: Story = {
 /** Use an array with more values for multiple thumbs. */
 export const MultipleThumbs: Story = {
   name: 'Multiple Thumbs',
+  parameters: { controls: { include: [] } },
   render: () => (
     <div className="w-80">
       <Slider
@@ -118,6 +163,7 @@ export const MultipleThumbs: Story = {
 
 /** Use `orientation="vertical"` for a vertical slider. */
 export const Vertical: Story = {
+  parameters: { controls: { include: [] } },
   render: () => (
     <Field className="items-center gap-3">
       <FieldLabel>Resource limit</FieldLabel>
@@ -134,11 +180,13 @@ export const Vertical: Story = {
 
 /** Control the slider value when another part of the UI depends on it. */
 export const Controlled: Story = {
+  parameters: { controls: { include: [] } },
   render: () => <ControlledSlider />,
 };
 
 /** Disabled sliders communicate the value without accepting interaction. */
 export const Disabled: Story = {
+  parameters: { controls: { include: [] } },
   render: () => (
     <div className="w-80">
       <Slider

--- a/stories/slider.stories.tsx
+++ b/stories/slider.stories.tsx
@@ -3,7 +3,13 @@ import { useState } from 'react';
 import { Field, FieldLabel } from '@/ui/field';
 import { Slider } from '@/ui/slider';
 
-function ControlledSlider() {
+function ControlledSlider({
+  disabled,
+  showValueTooltip,
+}: {
+  disabled?: boolean;
+  showValueTooltip?: boolean;
+}) {
   const [value, setValue] = useState<readonly number[]>([30, 70]);
 
   return (
@@ -15,6 +21,7 @@ function ControlledSlider() {
         </output>
       </div>
       <Slider
+        disabled={disabled}
         getThumbAriaLabel={(index) =>
           index === 0 ? 'Minimum temperature' : 'Maximum temperature'
         }
@@ -23,6 +30,7 @@ function ControlledSlider() {
         onValueChange={(nextValue) => {
           setValue(Array.isArray(nextValue) ? nextValue : [nextValue]);
         }}
+        showValueTooltip={showValueTooltip}
         step={1}
         value={value}
       />
@@ -132,10 +140,21 @@ export const Default: Story = {
 
 /** Use an array with two values for a range slider. */
 export const Range: Story = {
-  parameters: { controls: { include: [] } },
-  render: () => (
+  // `defaultValue` is the array that makes this a range, so it is fixed in the
+  // render rather than exposed as a (single-number) knob.
+  parameters: {
+    controls: {
+      include: ['min', 'max', 'step', 'showValueTooltip', 'disabled'],
+    },
+  },
+  render: ({
+    defaultValue: _defaultValue,
+    orientation: _orientation,
+    ...args
+  }) => (
     <div className="w-80">
       <Slider
+        {...args}
         defaultValue={[20, 80]}
         getThumbAriaLabel={(index) =>
           index === 0 ? 'Minimum resource window' : 'Maximum resource window'
@@ -149,10 +168,19 @@ export const Range: Story = {
 /** Use an array with more values for multiple thumbs. */
 export const MultipleThumbs: Story = {
   name: 'Multiple Thumbs',
-  parameters: { controls: { include: [] } },
-  render: () => (
+  parameters: {
+    controls: {
+      include: ['min', 'max', 'step', 'showValueTooltip', 'disabled'],
+    },
+  },
+  render: ({
+    defaultValue: _defaultValue,
+    orientation: _orientation,
+    ...args
+  }) => (
     <div className="w-80">
       <Slider
+        {...args}
         defaultValue={[20, 50, 80]}
         getThumbAriaLabel={(index) => `Resource checkpoint ${index + 1}`}
         minStepsBetweenValues={5}
@@ -163,15 +191,20 @@ export const MultipleThumbs: Story = {
 
 /** Use `orientation="vertical"` for a vertical slider. */
 export const Vertical: Story = {
-  parameters: { controls: { include: [] } },
-  render: () => (
+  args: { defaultValue: 60, orientation: 'vertical' },
+  parameters: {
+    controls: {
+      include: ['orientation', 'defaultValue', 'showValueTooltip', 'disabled'],
+    },
+  },
+  render: (args) => (
     <Field className="items-center gap-3">
       <FieldLabel>Resource limit</FieldLabel>
-      <div className="h-52">
+      <div className={args.orientation === 'vertical' ? 'h-52' : 'w-80'}>
         <Slider
-          defaultValue={60}
+          key={String(args.defaultValue)}
+          {...args}
           getThumbAriaLabel={() => 'Resource limit'}
-          orientation="vertical"
         />
       </div>
     </Field>
@@ -180,18 +213,24 @@ export const Vertical: Story = {
 
 /** Control the slider value when another part of the UI depends on it. */
 export const Controlled: Story = {
-  parameters: { controls: { include: [] } },
-  render: () => <ControlledSlider />,
+  // The example owns `value`, `min`, `max`, and `step`.
+  parameters: { controls: { include: ['showValueTooltip', 'disabled'] } },
+  render: ({ disabled, showValueTooltip }) => (
+    <ControlledSlider disabled={disabled} showValueTooltip={showValueTooltip} />
+  ),
 };
 
 /** Disabled sliders communicate the value without accepting interaction. */
 export const Disabled: Story = {
-  parameters: { controls: { include: [] } },
-  render: () => (
+  args: { defaultValue: 50, disabled: true },
+  parameters: {
+    controls: { include: ['disabled', 'defaultValue', 'showValueTooltip'] },
+  },
+  render: ({ orientation: _orientation, ...args }) => (
     <div className="w-80">
       <Slider
-        defaultValue={50}
-        disabled
+        key={String(args.defaultValue)}
+        {...args}
         getThumbAriaLabel={() => 'Storage quota'}
       />
     </div>

--- a/stories/slider.stories.tsx
+++ b/stories/slider.stories.tsx
@@ -117,6 +117,11 @@ const meta = {
       control: false,
     },
   },
+  decorators: [
+    // `defaultValue` is read once on mount, so key the story on it to remount
+    // when the control changes — otherwise the knob would silently do nothing.
+    (Story, { args }) => <Story key={String(args.defaultValue)} />,
+  ],
 } satisfies Meta<typeof Slider>;
 
 export default meta;
@@ -125,15 +130,9 @@ type Story = StoryObj<typeof meta>;
 
 /** The default slider selects a single value from a bounded range. */
 export const Default: Story = {
-  // `defaultValue` is read once on mount, so key the slider on it to remount
-  // when the control changes.
   render: (args) => (
     <div className={args.orientation === 'vertical' ? 'h-52' : 'w-80'}>
-      <Slider
-        key={String(args.defaultValue)}
-        {...args}
-        getThumbAriaLabel={() => 'Resource limit'}
-      />
+      <Slider {...args} getThumbAriaLabel={() => 'Resource limit'} />
     </div>
   ),
 };
@@ -167,7 +166,6 @@ export const Range: Story = {
 
 /** Use an array with more values for multiple thumbs. */
 export const MultipleThumbs: Story = {
-  name: 'Multiple Thumbs',
   parameters: {
     controls: {
       include: ['min', 'max', 'step', 'showValueTooltip', 'disabled'],
@@ -201,11 +199,7 @@ export const Vertical: Story = {
     <Field className="items-center gap-3">
       <FieldLabel>Resource limit</FieldLabel>
       <div className={args.orientation === 'vertical' ? 'h-52' : 'w-80'}>
-        <Slider
-          key={String(args.defaultValue)}
-          {...args}
-          getThumbAriaLabel={() => 'Resource limit'}
-        />
+        <Slider {...args} getThumbAriaLabel={() => 'Resource limit'} />
       </div>
     </Field>
   ),
@@ -228,11 +222,7 @@ export const Disabled: Story = {
   },
   render: ({ orientation: _orientation, ...args }) => (
     <div className="w-80">
-      <Slider
-        key={String(args.defaultValue)}
-        {...args}
-        getThumbAriaLabel={() => 'Storage quota'}
-      />
+      <Slider {...args} getThumbAriaLabel={() => 'Storage quota'} />
     </div>
   ),
 };

--- a/stories/slider.stories.tsx
+++ b/stories/slider.stories.tsx
@@ -118,8 +118,7 @@ const meta = {
     },
   },
   decorators: [
-    // `defaultValue` is read once on mount, so key the story on it to remount
-    // when the control changes — otherwise the knob would silently do nothing.
+    // `defaultValue` is mount-only, so the key forces a remount when it changes.
     (Story, { args }) => <Story key={String(args.defaultValue)} />,
   ],
 } satisfies Meta<typeof Slider>;
@@ -139,8 +138,7 @@ export const Default: Story = {
 
 /** Use an array with two values for a range slider. */
 export const Range: Story = {
-  // `defaultValue` is the array that makes this a range, so it is fixed in the
-  // render rather than exposed as a (single-number) knob.
+  // `defaultValue` is an array here, so the single-number knob drops out.
   parameters: {
     controls: {
       include: ['min', 'max', 'step', 'showValueTooltip', 'disabled'],
@@ -207,7 +205,6 @@ export const Vertical: Story = {
 
 /** Control the slider value when another part of the UI depends on it. */
 export const Controlled: Story = {
-  // The example owns `value`, `min`, `max`, and `step`.
   parameters: { controls: { include: ['showValueTooltip', 'disabled'] } },
   render: ({ disabled, showValueTooltip }) => (
     <ControlledSlider disabled={disabled} showValueTooltip={showValueTooltip} />

--- a/stories/slider.stories.tsx
+++ b/stories/slider.stories.tsx
@@ -89,7 +89,7 @@ const meta = {
       table: { defaultValue: { summary: '0' } },
     },
     orientation: {
-      control: 'inline-radio',
+      control: 'select',
       description:
         'Track direction. `vertical` fills from the bottom up and needs a fixed-height wrapper.',
       options: ['horizontal', 'vertical'],
@@ -138,10 +138,9 @@ export const Default: Story = {
 
 /** Use an array with two values for a range slider. */
 export const Range: Story = {
-  // `defaultValue` is an array here, so the single-number knob drops out.
   parameters: {
     controls: {
-      include: ['min', 'max', 'step', 'showValueTooltip', 'disabled'],
+      include: [],
     },
   },
   render: ({
@@ -166,7 +165,7 @@ export const Range: Story = {
 export const MultipleThumbs: Story = {
   parameters: {
     controls: {
-      include: ['min', 'max', 'step', 'showValueTooltip', 'disabled'],
+      include: [],
     },
   },
   render: ({
@@ -190,7 +189,7 @@ export const Vertical: Story = {
   args: { defaultValue: 60, orientation: 'vertical' },
   parameters: {
     controls: {
-      include: ['orientation', 'defaultValue', 'showValueTooltip', 'disabled'],
+      include: [],
     },
   },
   render: (args) => (
@@ -205,7 +204,7 @@ export const Vertical: Story = {
 
 /** Control the slider value when another part of the UI depends on it. */
 export const Controlled: Story = {
-  parameters: { controls: { include: ['showValueTooltip', 'disabled'] } },
+  parameters: { controls: { include: [] } },
   render: ({ disabled, showValueTooltip }) => (
     <ControlledSlider disabled={disabled} showValueTooltip={showValueTooltip} />
   ),
@@ -215,7 +214,7 @@ export const Controlled: Story = {
 export const Disabled: Story = {
   args: { defaultValue: 50, disabled: true },
   parameters: {
-    controls: { include: ['disabled', 'defaultValue', 'showValueTooltip'] },
+    controls: { include: [] },
   },
   render: ({ orientation: _orientation, ...args }) => (
     <div className="w-80">

--- a/stories/spinner.stories.tsx
+++ b/stories/spinner.stories.tsx
@@ -59,7 +59,7 @@ export const Sizes: Story = {
       },
     },
   },
-  render: () => (
+  render: (_args) => (
     <div className="flex items-center gap-4">
       <Spinner size="xs" />
       <Spinner size="sm" />

--- a/stories/spinner.stories.tsx
+++ b/stories/spinner.stories.tsx
@@ -49,6 +49,7 @@ export const Default: Story = {
 export const Sizes: Story = {
   name: 'Sizes',
   parameters: {
+    controls: { include: [] },
     docs: {
       description: {
         story:
@@ -70,6 +71,7 @@ export const Sizes: Story = {
 export const CustomColor: Story = {
   name: 'Custom color',
   parameters: {
+    controls: { include: [] },
     docs: {
       description: {
         story:
@@ -89,6 +91,7 @@ export const CustomColor: Story = {
 export const WithText: Story = {
   name: 'With visible text',
   parameters: {
+    controls: { include: [] },
     docs: {
       description: {
         story:
@@ -109,6 +112,7 @@ export const WithText: Story = {
 export const CustomLabel: Story = {
   name: 'Custom accessible label',
   parameters: {
+    controls: { include: ['size', 'label'] },
     docs: {
       description: {
         story:

--- a/stories/spinner.stories.tsx
+++ b/stories/spinner.stories.tsx
@@ -14,8 +14,6 @@ const meta = {
     },
   },
   args: {
-    // Both match the component's own defaults, so seeding them only gives the
-    // controls a populated initial state.
     label: 'Loading',
     size: 'default',
   },
@@ -53,7 +51,6 @@ export const Default: Story = {
 
 export const Sizes: Story = {
   parameters: {
-    // Every spinner fixes its own size, and `label` has its own story below.
     controls: { include: [] },
     docs: {
       description: {

--- a/stories/spinner.stories.tsx
+++ b/stories/spinner.stories.tsx
@@ -41,7 +41,6 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
-  name: 'Default',
   parameters: {
     docs: {
       description: {
@@ -53,7 +52,6 @@ export const Default: Story = {
 };
 
 export const Sizes: Story = {
-  name: 'Sizes',
   parameters: {
     // Every spinner fixes its own size, and `label` has its own story below.
     controls: { include: [] },
@@ -109,8 +107,6 @@ export const WithText: Story = {
     },
   },
   render: (args) => (
-    // The spinner is icon-only; pair it with text at the call site (this is how
-    // `Button` renders its `loadingText`).
     <span className="inline-flex items-center gap-2 text-muted-foreground text-sm">
       <Spinner {...args} />
       Fetching data…

--- a/stories/spinner.stories.tsx
+++ b/stories/spinner.stories.tsx
@@ -13,6 +13,12 @@ const meta = {
       },
     },
   },
+  args: {
+    // Both match the component's own defaults, so seeding them only gives the
+    // controls a populated initial state.
+    label: 'Loading',
+    size: 'default',
+  },
   argTypes: {
     size: {
       description:
@@ -49,6 +55,7 @@ export const Default: Story = {
 export const Sizes: Story = {
   name: 'Sizes',
   parameters: {
+    // Every spinner fixes its own size, and `label` has its own story below.
     controls: { include: [] },
     docs: {
       description: {
@@ -57,21 +64,22 @@ export const Sizes: Story = {
       },
     },
   },
-  render: (args) => (
+  render: () => (
     <div className="flex items-center gap-4">
-      <Spinner {...args} size="xs" />
-      <Spinner {...args} size="sm" />
-      <Spinner {...args} size="default" />
-      <Spinner {...args} size="lg" />
-      <Spinner {...args} size="xl" />
+      <Spinner size="xs" />
+      <Spinner size="sm" />
+      <Spinner size="default" />
+      <Spinner size="lg" />
+      <Spinner size="xl" />
     </div>
   ),
 };
 
 export const CustomColor: Story = {
   name: 'Custom color',
+  args: { size: 'lg' },
   parameters: {
-    controls: { include: [] },
+    controls: { include: ['size'] },
     docs: {
       description: {
         story:
@@ -81,17 +89,18 @@ export const CustomColor: Story = {
   },
   render: (args) => (
     <div className="flex items-center gap-4">
-      <Spinner {...args} className="text-primary" size="lg" />
-      <Spinner {...args} className="text-destructive-foreground" size="lg" />
-      <Spinner {...args} className="text-muted-foreground" size="lg" />
+      <Spinner {...args} className="text-primary" />
+      <Spinner {...args} className="text-destructive-foreground" />
+      <Spinner {...args} className="text-muted-foreground" />
     </div>
   ),
 };
 
 export const WithText: Story = {
   name: 'With visible text',
+  args: { size: 'sm' },
   parameters: {
-    controls: { include: [] },
+    controls: { include: ['size'] },
     docs: {
       description: {
         story:
@@ -103,7 +112,7 @@ export const WithText: Story = {
     // The spinner is icon-only; pair it with text at the call site (this is how
     // `Button` renders its `loadingText`).
     <span className="inline-flex items-center gap-2 text-muted-foreground text-sm">
-      <Spinner {...args} size="sm" />
+      <Spinner {...args} />
       Fetching data…
     </span>
   ),

--- a/stories/spinner.stories.tsx
+++ b/stories/spinner.stories.tsx
@@ -74,7 +74,7 @@ export const CustomColor: Story = {
   name: 'Custom color',
   args: { size: 'lg' },
   parameters: {
-    controls: { include: ['size'] },
+    controls: { include: [] },
     docs: {
       description: {
         story:
@@ -95,7 +95,7 @@ export const WithText: Story = {
   name: 'With visible text',
   args: { size: 'sm' },
   parameters: {
-    controls: { include: ['size'] },
+    controls: { include: [] },
     docs: {
       description: {
         story:
@@ -114,7 +114,7 @@ export const WithText: Story = {
 export const CustomLabel: Story = {
   name: 'Custom accessible label',
   parameters: {
-    controls: { include: ['size', 'label'] },
+    controls: { include: [] },
     docs: {
       description: {
         story:

--- a/stories/switch.stories.tsx
+++ b/stories/switch.stories.tsx
@@ -6,34 +6,73 @@ const meta = {
   title: 'Components/Switch',
   component: Switch,
   parameters: { layout: 'centered' },
+  args: { 'aria-label': 'Enable setting', defaultChecked: true },
+  argTypes: {
+    defaultChecked: {
+      description: 'Initial state when the switch is uncontrolled.',
+      control: 'boolean',
+      table: { defaultValue: { summary: 'false' } },
+    },
+    checked: {
+      description:
+        'Controlled state. Pair it with `onCheckedChange`; left as a docs-only row here so the playground stays interactive.',
+      control: false,
+    },
+    disabled: {
+      description:
+        'Dims the track and thumb to 50% opacity and blocks pointer and keyboard interaction.',
+      control: 'boolean',
+      table: { defaultValue: { summary: 'false' } },
+    },
+    required: {
+      description:
+        'Marks the switch as required for Base UI `Field` validation — the switch must be on to pass.',
+      control: 'boolean',
+      table: { defaultValue: { summary: 'false' } },
+    },
+    'aria-label': {
+      description:
+        'Accessible name for a standalone switch. Not needed inside a `Field` — `FieldLabel` names it instead.',
+      control: 'text',
+    },
+    onCheckedChange: {
+      description: 'Called with the next checked state on every toggle.',
+      action: 'checked changed',
+      control: false,
+    },
+    className: { table: { disable: true } },
+    render: {
+      description:
+        'Base UI render-prop composition. Swap the rendered element while preserving switch behavior, styling, and slot attributes.',
+      control: false,
+    },
+  },
+  decorators: [
+    // `defaultChecked` is read once on mount, so key the story on it to remount
+    // when the control changes — otherwise the knob would silently do nothing.
+    (Story, { args }) => <Story key={String(args.defaultChecked)} />,
+  ],
 } satisfies Meta<typeof Switch>;
 
 export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const On: Story = {
-  args: { 'aria-label': 'Enable setting', defaultChecked: true },
-};
+export const Default: Story = {};
 
 export const Off: Story = {
-  args: { 'aria-label': 'Enable setting', defaultChecked: false },
+  args: { defaultChecked: false },
+  parameters: { controls: { include: ['defaultChecked'] } },
 };
 
 export const Disabled: Story = {
-  args: {
-    'aria-label': 'Enable setting',
-    defaultChecked: true,
-    disabled: true,
-  },
+  args: { defaultChecked: true, disabled: true },
+  parameters: { controls: { include: ['defaultChecked', 'disabled'] } },
 };
 
 export const DisabledOff: Story = {
-  args: {
-    'aria-label': 'Enable setting',
-    defaultChecked: false,
-    disabled: true,
-  },
+  args: { defaultChecked: false, disabled: true },
+  parameters: { controls: { include: ['defaultChecked', 'disabled'] } },
 };
 
 /**
@@ -43,6 +82,7 @@ export const DisabledOff: Story = {
  * manual `id` / `aria-labelledby` wiring is needed.
  */
 export const WithLabel: Story = {
+  parameters: { controls: { include: [] } },
   render: () => (
     <Field className="w-64 flex-row items-start justify-between gap-4">
       <div className="flex flex-col gap-0.5">
@@ -61,6 +101,7 @@ export const WithLabel: Story = {
  * clicking anywhere toggles the switch.
  */
 export const Box: Story = {
+  parameters: { controls: { include: [] } },
   render: () => (
     <Field>
       <FieldLabel className="flex w-64 cursor-pointer items-center justify-between gap-4 rounded-md border border-border bg-background p-4 hover:bg-muted">

--- a/stories/switch.stories.tsx
+++ b/stories/switch.stories.tsx
@@ -66,17 +66,17 @@ export const Default: Story = {};
 
 export const Off: Story = {
   args: { defaultChecked: false },
-  parameters: { controls: { include: ['defaultChecked'] } },
+  parameters: { controls: { include: [] } },
 };
 
 export const Disabled: Story = {
   args: { defaultChecked: true, disabled: true },
-  parameters: { controls: { include: ['defaultChecked', 'disabled'] } },
+  parameters: { controls: { include: [] } },
 };
 
 export const DisabledOff: Story = {
   args: { defaultChecked: false, disabled: true },
-  parameters: { controls: { include: ['defaultChecked', 'disabled'] } },
+  parameters: { controls: { include: [] } },
 };
 
 /**
@@ -86,7 +86,7 @@ export const DisabledOff: Story = {
  * manual `id` / `aria-labelledby` wiring is needed.
  */
 export const WithLabel: Story = {
-  parameters: { controls: { include: ['defaultChecked', 'disabled'] } },
+  parameters: { controls: { include: [] } },
   // `Field` supplies the accessible name, so `aria-label` is dropped here.
   render: ({ 'aria-label': _ariaLabel, ...args }) => (
     <Field className="w-64 flex-row items-start justify-between gap-4">
@@ -106,7 +106,7 @@ export const WithLabel: Story = {
  * clicking anywhere toggles the switch.
  */
 export const Box: Story = {
-  parameters: { controls: { include: ['defaultChecked', 'disabled'] } },
+  parameters: { controls: { include: [] } },
   render: ({ 'aria-label': _ariaLabel, ...args }) => (
     <Field>
       <FieldLabel className="flex w-64 cursor-pointer items-center justify-between gap-4 rounded-md border border-border bg-background p-4 hover:bg-muted">

--- a/stories/switch.stories.tsx
+++ b/stories/switch.stories.tsx
@@ -53,8 +53,7 @@ const meta = {
     },
   },
   decorators: [
-    // `defaultChecked` is read once on mount, so key the story on it to remount
-    // when the control changes — otherwise the knob would silently do nothing.
+    // `defaultChecked` is mount-only, so the key forces a remount when it changes.
     (Story, { args }) => <Story key={String(args.defaultChecked)} />,
   ],
 } satisfies Meta<typeof Switch>;

--- a/stories/switch.stories.tsx
+++ b/stories/switch.stories.tsx
@@ -6,7 +6,12 @@ const meta = {
   title: 'Components/Switch',
   component: Switch,
   parameters: { layout: 'centered' },
-  args: { 'aria-label': 'Enable setting', defaultChecked: true },
+  args: {
+    'aria-label': 'Enable setting',
+    defaultChecked: true,
+    disabled: false,
+    required: false,
+  },
   argTypes: {
     defaultChecked: {
       description: 'Initial state when the switch is uncontrolled.',
@@ -82,8 +87,9 @@ export const DisabledOff: Story = {
  * manual `id` / `aria-labelledby` wiring is needed.
  */
 export const WithLabel: Story = {
-  parameters: { controls: { include: [] } },
-  render: () => (
+  parameters: { controls: { include: ['defaultChecked', 'disabled'] } },
+  // `Field` supplies the accessible name, so `aria-label` is dropped here.
+  render: ({ 'aria-label': _ariaLabel, ...args }) => (
     <Field className="w-64 flex-row items-start justify-between gap-4">
       <div className="flex flex-col gap-0.5">
         <FieldLabel>Enable copy</FieldLabel>
@@ -91,7 +97,7 @@ export const WithLabel: Story = {
           Allow users to copy this environment
         </FieldDescription>
       </div>
-      <Switch defaultChecked />
+      <Switch {...args} />
     </Field>
   ),
 };
@@ -101,12 +107,12 @@ export const WithLabel: Story = {
  * clicking anywhere toggles the switch.
  */
 export const Box: Story = {
-  parameters: { controls: { include: [] } },
-  render: () => (
+  parameters: { controls: { include: ['defaultChecked', 'disabled'] } },
+  render: ({ 'aria-label': _ariaLabel, ...args }) => (
     <Field>
       <FieldLabel className="flex w-64 cursor-pointer items-center justify-between gap-4 rounded-md border border-border bg-background p-4 hover:bg-muted">
         Deep Research
-        <Switch defaultChecked />
+        <Switch {...args} />
       </FieldLabel>
     </Field>
   ),

--- a/stories/table.stories.tsx
+++ b/stories/table.stories.tsx
@@ -194,7 +194,7 @@ export const Default: Story = {
 export const WithFooter: Story = {
   name: 'With footer',
   // The footer row spans the data columns, so the actions column affects it.
-  parameters: { controls: { include: ['showFooter', 'showActions'] } },
+  parameters: { controls: { include: [] } },
   args: {
     showFooter: true,
   },
@@ -206,7 +206,7 @@ export const WithFooter: Story = {
 };
 
 export const Actions: Story = {
-  parameters: { controls: { include: ['showActions', 'showFooter'] } },
+  parameters: { controls: { include: [] } },
   args: {
     showActions: true,
   },
@@ -220,7 +220,7 @@ export const Actions: Story = {
 export const EmptyState: Story = {
   name: 'Empty state',
   // The placeholder cell's `colSpan` tracks the actions column.
-  parameters: { controls: { include: ['empty', 'showActions'] } },
+  parameters: { controls: { include: [] } },
   args: {
     empty: true,
   },

--- a/stories/table.stories.tsx
+++ b/stories/table.stories.tsx
@@ -41,13 +41,6 @@ type TableStoryArgs = {
   showFooter: boolean;
 };
 
-const tableStoryDefaults = {
-  caption: '',
-  empty: false,
-  showActions: false,
-  showFooter: false,
-} satisfies TableStoryArgs;
-
 function TableFrame({ children }: { children: ReactNode }) {
   return <div className="w-[44rem] max-w-[calc(100vw-3rem)]">{children}</div>;
 }
@@ -110,11 +103,11 @@ function EnvironmentRows({ actions = false }: { actions?: boolean }) {
 }
 
 function EnvironmentTable({
-  caption,
-  empty,
-  showActions,
-  showFooter,
-}: TableStoryArgs) {
+  caption = '',
+  empty = false,
+  showActions = false,
+  showFooter = false,
+}: Partial<TableStoryArgs>) {
   const columnCount = showActions ? 5 : 4;
 
   return (
@@ -159,7 +152,7 @@ const meta = {
       },
     },
   },
-  args: tableStoryDefaults,
+  args: { caption: '', empty: false, showActions: false, showFooter: false },
   argTypes: {
     caption: {
       control: 'text',
@@ -193,7 +186,7 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   render: (args) => (
     <TableFrame>
-      <EnvironmentTable {...tableStoryDefaults} {...args} />
+      <EnvironmentTable {...args} />
     </TableFrame>
   ),
 };
@@ -207,7 +200,7 @@ export const WithFooter: Story = {
   },
   render: (args) => (
     <TableFrame>
-      <EnvironmentTable {...tableStoryDefaults} {...args} />
+      <EnvironmentTable {...args} />
     </TableFrame>
   ),
 };
@@ -219,7 +212,7 @@ export const Actions: Story = {
   },
   render: (args) => (
     <TableFrame>
-      <EnvironmentTable {...tableStoryDefaults} {...args} />
+      <EnvironmentTable {...args} />
     </TableFrame>
   ),
 };
@@ -233,7 +226,7 @@ export const EmptyState: Story = {
   },
   render: (args) => (
     <TableFrame>
-      <EnvironmentTable {...tableStoryDefaults} {...args} />
+      <EnvironmentTable {...args} />
     </TableFrame>
   ),
 };

--- a/stories/table.stories.tsx
+++ b/stories/table.stories.tsx
@@ -164,19 +164,24 @@ const meta = {
     caption: {
       control: 'text',
       description:
-        'Optional visible `TableCaption` text. Leave empty to omit the caption.',
-    },
-    empty: {
-      control: 'boolean',
-      description: 'Shows the table empty state instead of data rows.',
-    },
-    showActions: {
-      control: 'boolean',
-      description: 'Adds a copy/delete action column.',
+        'Story-only toggle. Optional visible `TableCaption` text — leave empty to omit the caption.',
+      table: { defaultValue: { summary: '(none)' } },
     },
     showFooter: {
       control: 'boolean',
-      description: 'Adds a summary footer row.',
+      description: 'Story-only toggle. Adds a summary `TableFooter` row.',
+      table: { defaultValue: { summary: 'false' } },
+    },
+    showActions: {
+      control: 'boolean',
+      description: 'Story-only toggle. Adds a copy/delete action column.',
+      table: { defaultValue: { summary: 'false' } },
+    },
+    empty: {
+      control: 'boolean',
+      description:
+        'Story-only toggle. Shows the table empty state instead of data rows.',
+      table: { defaultValue: { summary: 'false' } },
     },
   },
 } satisfies Meta<TableStoryArgs>;
@@ -195,6 +200,7 @@ export const Default: Story = {
 
 export const WithFooter: Story = {
   name: 'With footer',
+  parameters: { controls: { include: ['showFooter'] } },
   args: {
     showFooter: true,
   },
@@ -206,6 +212,7 @@ export const WithFooter: Story = {
 };
 
 export const Actions: Story = {
+  parameters: { controls: { include: ['showActions'] } },
   args: {
     showActions: true,
   },
@@ -218,6 +225,7 @@ export const Actions: Story = {
 
 export const EmptyState: Story = {
   name: 'Empty state',
+  parameters: { controls: { include: ['empty'] } },
   args: {
     empty: true,
   },

--- a/stories/table.stories.tsx
+++ b/stories/table.stories.tsx
@@ -200,7 +200,8 @@ export const Default: Story = {
 
 export const WithFooter: Story = {
   name: 'With footer',
-  parameters: { controls: { include: ['showFooter'] } },
+  // The footer row spans the data columns, so the actions column affects it.
+  parameters: { controls: { include: ['showFooter', 'showActions'] } },
   args: {
     showFooter: true,
   },
@@ -212,7 +213,7 @@ export const WithFooter: Story = {
 };
 
 export const Actions: Story = {
-  parameters: { controls: { include: ['showActions'] } },
+  parameters: { controls: { include: ['showActions', 'showFooter'] } },
   args: {
     showActions: true,
   },
@@ -225,7 +226,8 @@ export const Actions: Story = {
 
 export const EmptyState: Story = {
   name: 'Empty state',
-  parameters: { controls: { include: ['empty'] } },
+  // The placeholder cell's `colSpan` tracks the actions column.
+  parameters: { controls: { include: ['empty', 'showActions'] } },
   args: {
     empty: true,
   },

--- a/stories/tabs.stories.tsx
+++ b/stories/tabs.stories.tsx
@@ -1,6 +1,18 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { BarChart3, Code2, Eye, Settings } from 'lucide-react';
+import type { ComponentProps } from 'react';
 import { Tabs, TabsIndicator, TabsList, TabsPanel, TabsTab } from '@/ui/tabs';
+
+type TabsVariant = NonNullable<ComponentProps<typeof TabsList>['variant']>;
+
+type TabsStoryArgs = Pick<
+  ComponentProps<typeof Tabs>,
+  'defaultValue' | 'onValueChange' | 'orientation' | 'value'
+> & {
+  disabled?: boolean;
+  icons?: boolean;
+  variant: TabsVariant;
+};
 
 const meta = {
   title: 'Components/Tabs',
@@ -14,35 +26,63 @@ const meta = {
       },
     },
   },
+  args: {
+    defaultValue: 'overview',
+    disabled: false,
+    icons: false,
+    orientation: 'horizontal',
+    variant: 'pill',
+  },
   argTypes: {
+    variant: {
+      description:
+        'Visual style, set on `TabsList` and propagated to `TabsTab` and `TabsIndicator` through context. `pill` is a bordered card-colored pill; `underline` and `line` use an underline indicator; `toggle` renders a segmented control.',
+      control: 'select',
+      options: ['pill', 'underline', 'line', 'toggle'],
+      table: { defaultValue: { summary: 'pill' } },
+    },
+    orientation: {
+      description:
+        'Tab layout orientation managed by Base UI. `vertical` puts the list beside the panels.',
+      control: 'inline-radio',
+      options: ['horizontal', 'vertical'],
+      table: { defaultValue: { summary: 'horizontal' } },
+    },
     defaultValue: {
       description:
-        'Initial active tab value when the component is uncontrolled.',
-      control: 'text',
+        'Initial active tab value when the component is uncontrolled. This story uses named tab values; Base UI falls back to the tab index.',
+      control: 'select',
+      options: ['overview', 'analytics', 'settings', 'logs'],
       table: { defaultValue: { summary: '0' } },
     },
+    icons: {
+      description:
+        'Story-only toggle. Renders a leading `lucide-react` icon in each tab.',
+      control: 'boolean',
+      table: { defaultValue: { summary: 'false' } },
+    },
+    disabled: {
+      description:
+        'Story-only toggle. Disables the last tab — a disabled `TabsTab` stays visible but cannot be focused or selected.',
+      control: 'boolean',
+      table: { defaultValue: { summary: 'false' } },
+    },
     value: {
-      description: 'Controlled active tab value.',
-      control: 'text',
+      description:
+        'Controlled active tab value. Pair it with `onValueChange`; left as a docs-only row here so the playground stays interactive.',
+      control: false,
     },
     onValueChange: {
       description: 'Called when the active tab changes.',
       action: 'value changed',
       control: false,
     },
-    orientation: {
-      description: 'Tab layout orientation managed by Base UI.',
-      control: 'select',
-      options: ['horizontal', 'vertical'],
-      table: { defaultValue: { summary: 'horizontal' } },
-    },
   },
-} satisfies Meta<typeof Tabs>;
+} satisfies Meta<TabsStoryArgs>;
 
 export default meta;
 
-type Story = StoryObj<typeof meta>;
-type TabsVariant = 'pill' | 'underline';
+type Story = StoryObj<TabsStoryArgs>;
 
 function PanelCard({ children, title }: { children: string; title: string }) {
   return (
@@ -54,22 +94,20 @@ function PanelCard({ children, title }: { children: string; title: string }) {
 }
 
 function ExampleTabs({
+  defaultValue = 'overview',
   disabled = false,
   icons = false,
+  onValueChange,
   orientation = 'horizontal',
   variant,
-}: {
-  disabled?: boolean;
-  icons?: boolean;
-  orientation?: 'horizontal' | 'vertical';
-  variant: TabsVariant;
-}) {
+}: TabsStoryArgs) {
   const isVertical = orientation === 'vertical';
 
   return (
     <Tabs
       className={isVertical ? 'w-[620px]' : 'w-[520px]'}
-      defaultValue="overview"
+      defaultValue={defaultValue}
+      onValueChange={onValueChange}
       orientation={orientation}
     >
       <TabsList aria-label="Project sections" variant={variant}>
@@ -127,22 +165,25 @@ function ExampleTabs({
   );
 }
 
-export const Pill: Story = {
-  name: 'Pill',
+export const Default: Story = {
+  name: 'Default',
   parameters: {
     docs: {
       description: {
         story:
-          'The default pill style. Each tab is a bordered card-colored pill; disabled pills keep the same sizing and switch to the muted background.',
+          'The default pill style. Each tab is a bordered card-colored pill; disabled pills keep the same sizing and switch to the muted background. Use the controls to preview every variant, orientation, and the icon and disabled states.',
       },
     },
   },
-  render: () => <ExampleTabs variant="pill" />,
+  // `defaultValue` is read once on mount, so key the tabs on it to remount when
+  // the control changes — otherwise the knob would silently do nothing.
+  render: (args) => <ExampleTabs key={String(args.defaultValue)} {...args} />,
 };
 
 export const Underline: Story = {
   name: 'Underline',
   parameters: {
+    controls: { include: [] },
     docs: {
       description: {
         story:
@@ -156,6 +197,7 @@ export const Underline: Story = {
 export const Vertical: Story = {
   name: 'Vertical',
   parameters: {
+    controls: { include: [] },
     docs: {
       description: {
         story:
@@ -169,6 +211,7 @@ export const Vertical: Story = {
 export const Disabled: Story = {
   name: 'Disabled',
   parameters: {
+    controls: { include: [] },
     docs: {
       description: {
         story:
@@ -182,6 +225,7 @@ export const Disabled: Story = {
 export const Icons: Story = {
   name: 'Icons',
   parameters: {
+    controls: { include: [] },
     docs: {
       description: {
         story:

--- a/stories/tabs.stories.tsx
+++ b/stories/tabs.stories.tsx
@@ -182,8 +182,9 @@ export const Default: Story = {
 
 export const Underline: Story = {
   name: 'Underline',
+  args: { variant: 'underline' },
   parameters: {
-    controls: { include: [] },
+    controls: { include: ['variant', 'icons', 'disabled'] },
     docs: {
       description: {
         story:
@@ -191,13 +192,14 @@ export const Underline: Story = {
       },
     },
   },
-  render: () => <ExampleTabs variant="underline" />,
+  render: (args) => <ExampleTabs key={String(args.defaultValue)} {...args} />,
 };
 
 export const Vertical: Story = {
   name: 'Vertical',
+  args: { orientation: 'vertical' },
   parameters: {
-    controls: { include: [] },
+    controls: { include: ['orientation', 'variant', 'icons'] },
     docs: {
       description: {
         story:
@@ -205,13 +207,14 @@ export const Vertical: Story = {
       },
     },
   },
-  render: () => <ExampleTabs orientation="vertical" variant="pill" />,
+  render: (args) => <ExampleTabs key={String(args.defaultValue)} {...args} />,
 };
 
 export const Disabled: Story = {
   name: 'Disabled',
+  args: { disabled: true },
   parameters: {
-    controls: { include: [] },
+    controls: { include: ['disabled', 'variant'] },
     docs: {
       description: {
         story:
@@ -219,13 +222,14 @@ export const Disabled: Story = {
       },
     },
   },
-  render: () => <ExampleTabs disabled variant="pill" />,
+  render: (args) => <ExampleTabs key={String(args.defaultValue)} {...args} />,
 };
 
 export const Icons: Story = {
   name: 'Icons',
+  args: { icons: true },
   parameters: {
-    controls: { include: [] },
+    controls: { include: ['icons', 'variant'] },
     docs: {
       description: {
         story:
@@ -233,5 +237,5 @@ export const Icons: Story = {
       },
     },
   },
-  render: () => <ExampleTabs icons variant="pill" />,
+  render: (args) => <ExampleTabs key={String(args.defaultValue)} {...args} />,
 };

--- a/stories/tabs.stories.tsx
+++ b/stories/tabs.stories.tsx
@@ -78,6 +78,11 @@ const meta = {
       control: false,
     },
   },
+  decorators: [
+    // `defaultValue` is read once on mount, so key the story on it to remount
+    // when the control changes — otherwise the knob would silently do nothing.
+    (Story, { args }) => <Story key={String(args.defaultValue)} />,
+  ],
 } satisfies Meta<TabsStoryArgs>;
 
 export default meta;
@@ -166,7 +171,6 @@ function ExampleTabs({
 }
 
 export const Default: Story = {
-  name: 'Default',
   parameters: {
     docs: {
       description: {
@@ -175,13 +179,10 @@ export const Default: Story = {
       },
     },
   },
-  // `defaultValue` is read once on mount, so key the tabs on it to remount when
-  // the control changes — otherwise the knob would silently do nothing.
-  render: (args) => <ExampleTabs key={String(args.defaultValue)} {...args} />,
+  render: (args) => <ExampleTabs {...args} />,
 };
 
 export const Underline: Story = {
-  name: 'Underline',
   args: { variant: 'underline' },
   parameters: {
     controls: { include: ['variant', 'icons', 'disabled'] },
@@ -192,11 +193,10 @@ export const Underline: Story = {
       },
     },
   },
-  render: (args) => <ExampleTabs key={String(args.defaultValue)} {...args} />,
+  render: (args) => <ExampleTabs {...args} />,
 };
 
 export const Vertical: Story = {
-  name: 'Vertical',
   args: { orientation: 'vertical' },
   parameters: {
     controls: { include: ['orientation', 'variant', 'icons'] },
@@ -207,11 +207,10 @@ export const Vertical: Story = {
       },
     },
   },
-  render: (args) => <ExampleTabs key={String(args.defaultValue)} {...args} />,
+  render: (args) => <ExampleTabs {...args} />,
 };
 
 export const Disabled: Story = {
-  name: 'Disabled',
   args: { disabled: true },
   parameters: {
     controls: { include: ['disabled', 'variant'] },
@@ -222,11 +221,10 @@ export const Disabled: Story = {
       },
     },
   },
-  render: (args) => <ExampleTabs key={String(args.defaultValue)} {...args} />,
+  render: (args) => <ExampleTabs {...args} />,
 };
 
 export const Icons: Story = {
-  name: 'Icons',
   args: { icons: true },
   parameters: {
     controls: { include: ['icons', 'variant'] },
@@ -237,5 +235,5 @@ export const Icons: Story = {
       },
     },
   },
-  render: (args) => <ExampleTabs key={String(args.defaultValue)} {...args} />,
+  render: (args) => <ExampleTabs {...args} />,
 };

--- a/stories/tabs.stories.tsx
+++ b/stories/tabs.stories.tsx
@@ -79,8 +79,7 @@ const meta = {
     },
   },
   decorators: [
-    // `defaultValue` is read once on mount, so key the story on it to remount
-    // when the control changes — otherwise the knob would silently do nothing.
+    // `defaultValue` is mount-only, so the key forces a remount when it changes.
     (Story, { args }) => <Story key={String(args.defaultValue)} />,
   ],
 } satisfies Meta<TabsStoryArgs>;

--- a/stories/tabs.stories.tsx
+++ b/stories/tabs.stories.tsx
@@ -44,7 +44,7 @@ const meta = {
     orientation: {
       description:
         'Tab layout orientation managed by Base UI. `vertical` puts the list beside the panels.',
-      control: 'inline-radio',
+      control: 'select',
       options: ['horizontal', 'vertical'],
       table: { defaultValue: { summary: 'horizontal' } },
     },
@@ -184,7 +184,7 @@ export const Default: Story = {
 export const Underline: Story = {
   args: { variant: 'underline' },
   parameters: {
-    controls: { include: ['variant', 'icons', 'disabled'] },
+    controls: { include: [] },
     docs: {
       description: {
         story:
@@ -198,7 +198,7 @@ export const Underline: Story = {
 export const Vertical: Story = {
   args: { orientation: 'vertical' },
   parameters: {
-    controls: { include: ['orientation', 'variant', 'icons'] },
+    controls: { include: [] },
     docs: {
       description: {
         story:
@@ -212,7 +212,7 @@ export const Vertical: Story = {
 export const Disabled: Story = {
   args: { disabled: true },
   parameters: {
-    controls: { include: ['disabled', 'variant'] },
+    controls: { include: [] },
     docs: {
       description: {
         story:
@@ -226,7 +226,7 @@ export const Disabled: Story = {
 export const Icons: Story = {
   args: { icons: true },
   parameters: {
-    controls: { include: ['icons', 'variant'] },
+    controls: { include: [] },
     docs: {
       description: {
         story:

--- a/stories/textarea.stories.tsx
+++ b/stories/textarea.stories.tsx
@@ -8,10 +8,57 @@ const meta = {
   component: Textarea,
   parameters: { layout: 'centered' },
   args: { placeholder: 'Placeholder text' },
+  argTypes: {
+    placeholder: {
+      description: 'Hint text shown while the textarea is empty.',
+      control: 'text',
+    },
+    defaultValue: {
+      description: 'Initial value when the textarea is uncontrolled.',
+      control: 'text',
+    },
+    value: {
+      description:
+        'Controlled value. Pair it with `onChange`; left as a docs-only row here so the playground stays interactive.',
+      control: false,
+    },
+    rows: {
+      description:
+        'Visible line count. The control also has a `min-h-16` floor, so small values are clamped by the minimum height.',
+      control: { type: 'number', min: 1, max: 12, step: 1 },
+    },
+    disabled: {
+      description:
+        'Dims the textarea to `bg-muted`, blocks pointer events, and disables resizing.',
+      control: 'boolean',
+      table: { defaultValue: { summary: 'false' } },
+    },
+    required: {
+      description:
+        'Marks the textarea as required for native and Base UI `Field` validation.',
+      control: 'boolean',
+      table: { defaultValue: { summary: 'false' } },
+    },
+    readOnly: {
+      description:
+        'Keeps the value focusable and selectable but not editable — still resizeable, unlike `disabled`.',
+      control: 'boolean',
+      table: { defaultValue: { summary: 'false' } },
+    },
+    'aria-invalid': {
+      description:
+        'Renders the invalid state — a 2px `destructive` outline plus a trailing `triangle-alert` icon.',
+      control: 'boolean',
+      table: { defaultValue: { summary: 'false' } },
+    },
+    className: { table: { disable: true } },
+  },
   decorators: [
-    (Story) => (
+    // `defaultValue` is read once on mount, so key the story on it to remount
+    // when the control changes — otherwise the knob would silently do nothing.
+    (Story, { args }) => (
       <div className="w-64">
-        <Story />
+        <Story key={String(args.defaultValue)} />
       </div>
     ),
   ],
@@ -25,10 +72,14 @@ export const Default: Story = {};
 
 export const Filled: Story = {
   args: { defaultValue: 'A short description of this environment.' },
+  parameters: { controls: { include: ['defaultValue'] } },
 };
 
 /** Disabled is dimmed, non-interactive, and cannot be resized. */
-export const Disabled: Story = { args: { disabled: true } };
+export const Disabled: Story = {
+  args: { disabled: true },
+  parameters: { controls: { include: ['disabled'] } },
+};
 
 /**
  * The error state pairs the 2px `destructive` outline with a trailing
@@ -36,6 +87,7 @@ export const Disabled: Story = { args: { disabled: true } };
  * than color alone (WCAG 1.4.1).
  */
 export const WithError: Story = {
+  parameters: { controls: { include: [] } },
   render: () => (
     <Field>
       <FieldLabel>Description</FieldLabel>
@@ -47,6 +99,7 @@ export const WithError: Story = {
 
 /** Composed in a `Field` — rendered as the control so it auto-associates. */
 export const WithField: Story = {
+  parameters: { controls: { include: [] } },
   render: () => (
     <Field>
       <FieldLabel>Description</FieldLabel>

--- a/stories/textarea.stories.tsx
+++ b/stories/textarea.stories.tsx
@@ -7,7 +7,15 @@ const meta = {
   title: 'Components/Textarea',
   component: Textarea,
   parameters: { layout: 'centered' },
-  args: { placeholder: 'Placeholder text' },
+  args: {
+    'aria-invalid': false,
+    disabled: false,
+    placeholder: 'Placeholder text',
+    readOnly: false,
+    required: false,
+    // Matches the browser default, so the seeded knob is behavior-neutral.
+    rows: 2,
+  },
   argTypes: {
     placeholder: {
       description: 'Hint text shown while the textarea is empty.',
@@ -72,13 +80,13 @@ export const Default: Story = {};
 
 export const Filled: Story = {
   args: { defaultValue: 'A short description of this environment.' },
-  parameters: { controls: { include: ['defaultValue'] } },
+  parameters: { controls: { include: ['defaultValue', 'rows'] } },
 };
 
 /** Disabled is dimmed, non-interactive, and cannot be resized. */
 export const Disabled: Story = {
   args: { disabled: true },
-  parameters: { controls: { include: ['disabled'] } },
+  parameters: { controls: { include: ['disabled', 'defaultValue'] } },
 };
 
 /**
@@ -87,11 +95,12 @@ export const Disabled: Story = {
  * than color alone (WCAG 1.4.1).
  */
 export const WithError: Story = {
-  parameters: { controls: { include: [] } },
-  render: () => (
+  args: { 'aria-invalid': true },
+  parameters: { controls: { include: ['aria-invalid', 'rows'] } },
+  render: (args) => (
     <Field>
       <FieldLabel>Description</FieldLabel>
-      <FieldPrimitive.Control render={<Textarea aria-invalid />} />
+      <FieldPrimitive.Control render={<Textarea {...args} />} />
       <FieldError match>This field is required.</FieldError>
     </Field>
   ),
@@ -99,11 +108,14 @@ export const WithError: Story = {
 
 /** Composed in a `Field` — rendered as the control so it auto-associates. */
 export const WithField: Story = {
-  parameters: { controls: { include: [] } },
-  render: () => (
+  args: { placeholder: 'Describe this environment…' },
+  parameters: {
+    controls: { include: ['placeholder', 'rows', 'disabled', 'required'] },
+  },
+  render: (args) => (
     <Field>
       <FieldLabel>Description</FieldLabel>
-      <FieldPrimitive.Control render={<Textarea />} />
+      <FieldPrimitive.Control render={<Textarea {...args} />} />
       <FieldDescription>Markdown is supported.</FieldDescription>
     </Field>
   ),

--- a/stories/textarea.stories.tsx
+++ b/stories/textarea.stories.tsx
@@ -13,7 +13,6 @@ const meta = {
     placeholder: 'Placeholder text',
     readOnly: false,
     required: false,
-    // Matches the browser default, so the seeded knob is behavior-neutral.
     rows: 2,
   },
   argTypes: {
@@ -62,8 +61,7 @@ const meta = {
     className: { table: { disable: true } },
   },
   decorators: [
-    // `defaultValue` is read once on mount, so key the story on it to remount
-    // when the control changes — otherwise the knob would silently do nothing.
+    // `defaultValue` is mount-only, so the key forces a remount when it changes.
     (Story, { args }) => (
       <div className="w-64">
         <Story key={String(args.defaultValue)} />

--- a/stories/textarea.stories.tsx
+++ b/stories/textarea.stories.tsx
@@ -78,13 +78,13 @@ export const Default: Story = {};
 
 export const Filled: Story = {
   args: { defaultValue: 'A short description of this environment.' },
-  parameters: { controls: { include: ['defaultValue', 'rows'] } },
+  parameters: { controls: { include: [] } },
 };
 
 /** Disabled is dimmed, non-interactive, and cannot be resized. */
 export const Disabled: Story = {
   args: { disabled: true },
-  parameters: { controls: { include: ['disabled', 'defaultValue'] } },
+  parameters: { controls: { include: [] } },
 };
 
 /**
@@ -94,7 +94,7 @@ export const Disabled: Story = {
  */
 export const WithError: Story = {
   args: { 'aria-invalid': true },
-  parameters: { controls: { include: ['aria-invalid', 'rows'] } },
+  parameters: { controls: { include: [] } },
   render: (args) => (
     <Field>
       <FieldLabel>Description</FieldLabel>
@@ -108,7 +108,7 @@ export const WithError: Story = {
 export const WithField: Story = {
   args: { placeholder: 'Describe this environment…' },
   parameters: {
-    controls: { include: ['placeholder', 'rows', 'disabled', 'required'] },
+    controls: { include: [] },
   },
   render: (args) => (
     <Field>

--- a/stories/tooltip.stories.tsx
+++ b/stories/tooltip.stories.tsx
@@ -121,54 +121,20 @@ export const Sides: Story = {
   },
   render: ({ children: _children, side: _side, ...args }) => (
     <div className="grid grid-cols-2 items-center justify-items-center gap-6 sm:grid-cols-4">
-      <Tooltip>
-        <TooltipTrigger
-          render={
-            <Button className={triggerButtonClassName} variant="outline" />
-          }
-        >
-          Left
-        </TooltipTrigger>
-        <TooltipContent {...args} side="left">
-          Left Tooltip
-        </TooltipContent>
-      </Tooltip>
-      <Tooltip>
-        <TooltipTrigger
-          render={
-            <Button className={triggerButtonClassName} variant="outline" />
-          }
-        >
-          Top
-        </TooltipTrigger>
-        <TooltipContent {...args} side="top">
-          Top Tooltip
-        </TooltipContent>
-      </Tooltip>
-      <Tooltip>
-        <TooltipTrigger
-          render={
-            <Button className={triggerButtonClassName} variant="outline" />
-          }
-        >
-          Bottom
-        </TooltipTrigger>
-        <TooltipContent {...args} side="bottom">
-          Bottom Tooltip
-        </TooltipContent>
-      </Tooltip>
-      <Tooltip>
-        <TooltipTrigger
-          render={
-            <Button className={triggerButtonClassName} variant="outline" />
-          }
-        >
-          Right
-        </TooltipTrigger>
-        <TooltipContent {...args} side="right">
-          Right Tooltip
-        </TooltipContent>
-      </Tooltip>
+      {(['left', 'top', 'bottom', 'right'] as const).map((side) => (
+        <Tooltip key={side}>
+          <TooltipTrigger
+            render={
+              <Button className={triggerButtonClassName} variant="outline" />
+            }
+          >
+            <span className="capitalize">{side}</span>
+          </TooltipTrigger>
+          <TooltipContent {...args} side={side}>
+            <span className="capitalize">{side}</span> Tooltip
+          </TooltipContent>
+        </Tooltip>
+      ))}
     </div>
   ),
 };

--- a/stories/tooltip.stories.tsx
+++ b/stories/tooltip.stories.tsx
@@ -87,6 +87,18 @@ type Story = StoryObj<typeof meta>;
 
 const triggerButtonClassName = 'min-w-24 leading-none';
 
+/**
+ * Every story below fixes its own tooltip text, so `children` drops out of the
+ * controls while the whole positioning surface stays live.
+ */
+const positioningControls = [
+  'side',
+  'align',
+  'sideOffset',
+  'alignOffset',
+  'showArrow',
+];
+
 export const Default: Story = {
   render: ({ children, ...args }) => (
     <Tooltip>
@@ -101,8 +113,13 @@ export const Default: Story = {
 };
 
 export const Sides: Story = {
-  parameters: { controls: { include: [] } },
-  render: () => (
+  // Each tooltip fixes its own `side`.
+  parameters: {
+    controls: {
+      include: positioningControls.filter((prop) => prop !== 'side'),
+    },
+  },
+  render: ({ children: _children, side: _side, ...args }) => (
     <div className="grid grid-cols-2 items-center justify-items-center gap-6 sm:grid-cols-4">
       <Tooltip>
         <TooltipTrigger
@@ -112,7 +129,9 @@ export const Sides: Story = {
         >
           Left
         </TooltipTrigger>
-        <TooltipContent side="left">Left Tooltip</TooltipContent>
+        <TooltipContent {...args} side="left">
+          Left Tooltip
+        </TooltipContent>
       </Tooltip>
       <Tooltip>
         <TooltipTrigger
@@ -122,7 +141,9 @@ export const Sides: Story = {
         >
           Top
         </TooltipTrigger>
-        <TooltipContent side="top">Top Tooltip</TooltipContent>
+        <TooltipContent {...args} side="top">
+          Top Tooltip
+        </TooltipContent>
       </Tooltip>
       <Tooltip>
         <TooltipTrigger
@@ -132,7 +153,9 @@ export const Sides: Story = {
         >
           Bottom
         </TooltipTrigger>
-        <TooltipContent side="bottom">Bottom Tooltip</TooltipContent>
+        <TooltipContent {...args} side="bottom">
+          Bottom Tooltip
+        </TooltipContent>
       </Tooltip>
       <Tooltip>
         <TooltipTrigger
@@ -142,7 +165,9 @@ export const Sides: Story = {
         >
           Right
         </TooltipTrigger>
-        <TooltipContent side="right">Right Tooltip</TooltipContent>
+        <TooltipContent {...args} side="right">
+          Right Tooltip
+        </TooltipContent>
       </Tooltip>
     </div>
   ),
@@ -150,8 +175,8 @@ export const Sides: Story = {
 
 export const SupplementalInfo: Story = {
   name: 'Supplemental info',
-  parameters: { controls: { include: [] } },
-  render: () => (
+  parameters: { controls: { include: positioningControls } },
+  render: ({ children: _children, ...args }) => (
     <div className="flex items-center gap-2">
       <span className="font-medium text-sm">Workspace settings</span>
       <Tooltip>
@@ -163,7 +188,7 @@ export const SupplementalInfo: Story = {
             </Button>
           }
         />
-        <TooltipContent>
+        <TooltipContent {...args}>
           Configure compute, access, and notifications.
         </TooltipContent>
       </Tooltip>
@@ -173,8 +198,8 @@ export const SupplementalInfo: Story = {
 
 export const WithShortcut: Story = {
   name: 'With shortcut',
-  parameters: { controls: { include: [] } },
-  render: () => (
+  parameters: { controls: { include: positioningControls } },
+  render: ({ children: _children, ...args }) => (
     <Tooltip>
       <TooltipTrigger
         render={<Button className={triggerButtonClassName} variant="outline" />}
@@ -182,7 +207,7 @@ export const WithShortcut: Story = {
         <CopyIcon />
         Copy
       </TooltipTrigger>
-      <TooltipContent>
+      <TooltipContent {...args}>
         Copy link
         <kbd data-slot="kbd">Ctrl+C</kbd>
       </TooltipContent>
@@ -191,8 +216,8 @@ export const WithShortcut: Story = {
 };
 
 export const Focus: Story = {
-  parameters: { controls: { include: [] } },
-  render: () => (
+  parameters: { controls: { include: positioningControls } },
+  render: ({ children: _children, ...args }) => (
     <Tooltip>
       <TooltipTrigger
         render={<Button className={triggerButtonClassName} variant="outline" />}
@@ -200,7 +225,7 @@ export const Focus: Story = {
         <CircleHelpIcon />
         Focus me
       </TooltipTrigger>
-      <TooltipContent>
+      <TooltipContent {...args}>
         Tooltips are available from keyboard focus, not only pointer hover.
       </TooltipContent>
     </Tooltip>

--- a/stories/tooltip.stories.tsx
+++ b/stories/tooltip.stories.tsx
@@ -87,10 +87,6 @@ type Story = StoryObj<typeof meta>;
 
 const triggerButtonClassName = 'min-w-24 leading-none';
 
-/**
- * Every story below fixes its own tooltip text, so `children` drops out of the
- * controls while the whole positioning surface stays live.
- */
 const positioningControls = [
   'side',
   'align',
@@ -113,7 +109,6 @@ export const Default: Story = {
 };
 
 export const Sides: Story = {
-  // Each tooltip fixes its own `side`.
   parameters: {
     controls: {
       include: positioningControls.filter((prop) => prop !== 'side'),

--- a/stories/tooltip.stories.tsx
+++ b/stories/tooltip.stories.tsx
@@ -87,14 +87,6 @@ type Story = StoryObj<typeof meta>;
 
 const triggerButtonClassName = 'min-w-24 leading-none';
 
-const positioningControls = [
-  'side',
-  'align',
-  'sideOffset',
-  'alignOffset',
-  'showArrow',
-];
-
 export const Default: Story = {
   render: ({ children, ...args }) => (
     <Tooltip>
@@ -111,7 +103,7 @@ export const Default: Story = {
 export const Sides: Story = {
   parameters: {
     controls: {
-      include: positioningControls.filter((prop) => prop !== 'side'),
+      include: [],
     },
   },
   render: ({ children: _children, side: _side, ...args }) => (
@@ -136,7 +128,7 @@ export const Sides: Story = {
 
 export const SupplementalInfo: Story = {
   name: 'Supplemental info',
-  parameters: { controls: { include: positioningControls } },
+  parameters: { controls: { include: [] } },
   render: ({ children: _children, ...args }) => (
     <div className="flex items-center gap-2">
       <span className="font-medium text-sm">Workspace settings</span>
@@ -159,7 +151,7 @@ export const SupplementalInfo: Story = {
 
 export const WithShortcut: Story = {
   name: 'With shortcut',
-  parameters: { controls: { include: positioningControls } },
+  parameters: { controls: { include: [] } },
   render: ({ children: _children, ...args }) => (
     <Tooltip>
       <TooltipTrigger
@@ -177,7 +169,7 @@ export const WithShortcut: Story = {
 };
 
 export const Focus: Story = {
-  parameters: { controls: { include: positioningControls } },
+  parameters: { controls: { include: [] } },
   render: ({ children: _children, ...args }) => (
     <Tooltip>
       <TooltipTrigger

--- a/stories/tooltip.stories.tsx
+++ b/stories/tooltip.stories.tsx
@@ -55,7 +55,11 @@ const meta = {
     className: { table: { disable: true } },
     id: { table: { disable: true } },
     portalProps: { table: { disable: true } },
-    render: { table: { disable: true } },
+    render: {
+      description:
+        'Base UI render-prop composition. Swap the tooltip content element while preserving positioning, styling, and slot attributes.',
+      control: false,
+    },
     role: { table: { disable: true } },
     style: { table: { disable: true } },
   },
@@ -97,6 +101,7 @@ export const Default: Story = {
 };
 
 export const Sides: Story = {
+  parameters: { controls: { include: [] } },
   render: () => (
     <div className="grid grid-cols-2 items-center justify-items-center gap-6 sm:grid-cols-4">
       <Tooltip>
@@ -145,6 +150,7 @@ export const Sides: Story = {
 
 export const SupplementalInfo: Story = {
   name: 'Supplemental info',
+  parameters: { controls: { include: [] } },
   render: () => (
     <div className="flex items-center gap-2">
       <span className="font-medium text-sm">Workspace settings</span>
@@ -167,6 +173,7 @@ export const SupplementalInfo: Story = {
 
 export const WithShortcut: Story = {
   name: 'With shortcut',
+  parameters: { controls: { include: [] } },
   render: () => (
     <Tooltip>
       <TooltipTrigger
@@ -184,6 +191,7 @@ export const WithShortcut: Story = {
 };
 
 export const Focus: Story = {
+  parameters: { controls: { include: [] } },
   render: () => (
     <Tooltip>
       <TooltipTrigger

--- a/tests/code-block.test.tsx
+++ b/tests/code-block.test.tsx
@@ -152,51 +152,6 @@ describe('CodeBlock', () => {
     expect(header).toHaveAttribute('data-slot', 'code-block-header');
   });
 
-  it('puts the copy button in the header instead of floating it', () => {
-    render(
-      <CodeBlock code={snippet}>
-        <CodeBlockHeader>script.ts</CodeBlockHeader>
-        <CodeBlockBody />
-      </CodeBlock>,
-    );
-
-    const header = screen.getByText('script.ts');
-    const button = screen.getByRole('button', { name: 'Copy code' });
-    expect(header).toContainElement(button);
-    // A header bar is the copy button's home, so the root does not also float
-    // one over the body — that is what produced two buttons.
-    expect(button).not.toHaveAttribute('data-floating');
-    expect(screen.getAllByRole('button')).toHaveLength(1);
-  });
-
-  it('finds a header nested in a fragment', () => {
-    render(
-      <CodeBlock code={snippet}>
-        {/* biome-ignore lint/complexity/noUselessFragments: the fragment is the case under test */}
-        <>
-          <CodeBlockHeader>script.ts</CodeBlockHeader>
-          <CodeBlockBody />
-        </>
-      </CodeBlock>,
-    );
-
-    expect(screen.getAllByRole('button')).toHaveLength(1);
-    expect(
-      screen.getByRole('button', { name: 'Copy code' }),
-    ).not.toHaveAttribute('data-floating');
-  });
-
-  it('omits the header copy button when showCopyButton is false', () => {
-    render(
-      <CodeBlock code={snippet} showCopyButton={false}>
-        <CodeBlockHeader>script.ts</CodeBlockHeader>
-        <CodeBlockBody />
-      </CodeBlock>,
-    );
-
-    expect(screen.queryByRole('button')).not.toBeInTheDocument();
-  });
-
   it('renders an aria-hidden, non-selectable line-number gutter when showLineNumbers is set', () => {
     render(
       <CodeBlock code={snippet} showLineNumbers>
@@ -253,8 +208,10 @@ describe('CodeBlock', () => {
     mockClipboard(writeText);
 
     render(
-      <CodeBlock code={snippet}>
-        <CodeBlockHeader>script.ts</CodeBlockHeader>
+      <CodeBlock code={snippet} showCopyButton={false}>
+        <CodeBlockHeader>
+          <CodeBlockCopyButton />
+        </CodeBlockHeader>
         <CodeBlockBody />
       </CodeBlock>,
     );
@@ -274,8 +231,6 @@ describe('CodeBlock', () => {
     const writeText = vi.fn().mockRejectedValue(new Error('denied'));
     mockClipboard(writeText);
 
-    // `showCopyButton={false}` plus a hand-placed button is the escape hatch for
-    // custom placement — the block renders none of its own.
     render(
       <CodeBlock code={snippet} showCopyButton={false}>
         <CodeBlockCopyButton />
@@ -385,9 +340,6 @@ describe('CodeBlock', () => {
   it('throws when a slot is used outside CodeBlock', () => {
     const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
     expect(() => render(<CodeBlockBody />)).toThrow(
-      /must be used within a <CodeBlock>/,
-    );
-    expect(() => render(<CodeBlockHeader />)).toThrow(
       /must be used within a <CodeBlock>/,
     );
     spy.mockRestore();

--- a/tests/code-block.test.tsx
+++ b/tests/code-block.test.tsx
@@ -152,6 +152,51 @@ describe('CodeBlock', () => {
     expect(header).toHaveAttribute('data-slot', 'code-block-header');
   });
 
+  it('puts the copy button in the header instead of floating it', () => {
+    render(
+      <CodeBlock code={snippet}>
+        <CodeBlockHeader>script.ts</CodeBlockHeader>
+        <CodeBlockBody />
+      </CodeBlock>,
+    );
+
+    const header = screen.getByText('script.ts');
+    const button = screen.getByRole('button', { name: 'Copy code' });
+    expect(header).toContainElement(button);
+    // A header bar is the copy button's home, so the root does not also float
+    // one over the body — that is what produced two buttons.
+    expect(button).not.toHaveAttribute('data-floating');
+    expect(screen.getAllByRole('button')).toHaveLength(1);
+  });
+
+  it('finds a header nested in a fragment', () => {
+    render(
+      <CodeBlock code={snippet}>
+        {/* biome-ignore lint/complexity/noUselessFragments: the fragment is the case under test */}
+        <>
+          <CodeBlockHeader>script.ts</CodeBlockHeader>
+          <CodeBlockBody />
+        </>
+      </CodeBlock>,
+    );
+
+    expect(screen.getAllByRole('button')).toHaveLength(1);
+    expect(
+      screen.getByRole('button', { name: 'Copy code' }),
+    ).not.toHaveAttribute('data-floating');
+  });
+
+  it('omits the header copy button when showCopyButton is false', () => {
+    render(
+      <CodeBlock code={snippet} showCopyButton={false}>
+        <CodeBlockHeader>script.ts</CodeBlockHeader>
+        <CodeBlockBody />
+      </CodeBlock>,
+    );
+
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
   it('renders an aria-hidden, non-selectable line-number gutter when showLineNumbers is set', () => {
     render(
       <CodeBlock code={snippet} showLineNumbers>
@@ -208,10 +253,8 @@ describe('CodeBlock', () => {
     mockClipboard(writeText);
 
     render(
-      <CodeBlock code={snippet} showCopyButton={false}>
-        <CodeBlockHeader>
-          <CodeBlockCopyButton />
-        </CodeBlockHeader>
+      <CodeBlock code={snippet}>
+        <CodeBlockHeader>script.ts</CodeBlockHeader>
         <CodeBlockBody />
       </CodeBlock>,
     );
@@ -231,6 +274,8 @@ describe('CodeBlock', () => {
     const writeText = vi.fn().mockRejectedValue(new Error('denied'));
     mockClipboard(writeText);
 
+    // `showCopyButton={false}` plus a hand-placed button is the escape hatch for
+    // custom placement — the block renders none of its own.
     render(
       <CodeBlock code={snippet} showCopyButton={false}>
         <CodeBlockCopyButton />
@@ -340,6 +385,9 @@ describe('CodeBlock', () => {
   it('throws when a slot is used outside CodeBlock', () => {
     const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
     expect(() => render(<CodeBlockBody />)).toThrow(
+      /must be used within a <CodeBlock>/,
+    );
+    expect(() => render(<CodeBlockHeader />)).toThrow(
       /must be used within a <CodeBlock>/,
     );
     spy.mockRestore();

--- a/tests/story-controls.test.ts
+++ b/tests/story-controls.test.ts
@@ -8,10 +8,6 @@ import { describe, expect, it } from 'vitest';
  * table — so without this test a missing `controls.include` or a typo in an
  * `include` list fails silently.
  *
- * `Default` is the only playground: it exposes the full prop surface, and every
- * other story narrows to `include: []` unless it declares its own story-only
- * `argTypes`.
- *
  * Review-time concerns, not statically derivable: an omitted prop (`cva()` does
  * not expose its config at runtime, so there is no full prop surface to diff
  * against), whether a render *uses* the args it takes, and rule 8's remount
@@ -41,9 +37,9 @@ type Story = StoryObj<unknown> & {
 };
 
 /**
- * A `render` declared as `() => …` cannot receive args, so any control the story
- * exposes is unreachable. `undefined` means the component renders with args
- * directly, which is always fine.
+ * Storybook derives `__isArgsStory` from `render && render.length > 0`, and
+ * skips `controls.include` when it is false. `undefined` means the renderer
+ * supplies an args-taking default render, which is always fine.
  */
 function renderArity(story: Story): number | undefined {
   return typeof story.render === 'function' ? story.render.length : undefined;
@@ -82,7 +78,6 @@ function controlType(argType: unknown): string | undefined {
   return undefined;
 }
 
-/** Radio widgets are not used; every union is a `select`. */
 const BANNED_CONTROLS = new Set(['radio', 'inline-radio']);
 
 it('finds every component story', () => {
@@ -108,16 +103,12 @@ describe.each(componentStories)('$path', ({ mod }) => {
     expect(Object.keys(story?.args ?? {})).toEqual([]);
   });
 
-  it('routes every exposed control into the render', () => {
-    const unreachable = stories
-      .filter(([, story]) => {
-        const include = story.parameters?.controls?.include;
-        return Array.isArray(include) && include.length > 0;
-      })
+  it('keeps every render args-aware so controls.include applies', () => {
+    const unfiltered = stories
       .filter(([, story]) => renderArity(story) === 0)
       .map(([name]) => name);
 
-    expect(unreachable).toEqual([]);
+    expect(unfiltered).toEqual([]);
   });
 
   it('seeds every knob whose control would otherwise need a click', () => {
@@ -148,8 +139,6 @@ describe.each(componentStories)('$path', ({ mod }) => {
   });
 
   it('shows only controls that belong to the story exclusively', () => {
-    // Meta argTypes are the `Default` playground's surface. A non-Default story
-    // may expose a knob only if it declares that knob itself.
     const shared = stories
       .filter(([name]) => name !== 'Default')
       .flatMap(([name, story]) => {

--- a/tests/story-controls.test.ts
+++ b/tests/story-controls.test.ts
@@ -19,12 +19,12 @@ import { describe, expect, it } from 'vitest';
  * - **Whether a render actually *uses* the args it receives.** Arity is
  *   checkable (below); use is not. A render taking `args` and ignoring them
  *   stays a review-time concern.
- * - **The inverse — a fixed showcase reading args it cannot expose.** Not
- *   separable from the legitimate case: a `controls.include: []` showcase may
- *   still spread baseline meta args into each hardcoded instance (see
- *   `Variants` in `stories/button.stories.tsx`), which is the documented
- *   pattern. Arity cannot distinguish the two.
- * - **Rule 7 (mount-only props keyed to force a remount).** Not detectable
+ * - **Whether an `include` list is the *right* set.** "Applicable to this
+ *   story" depends on what the render hardcodes, which is not statically
+ *   derivable. The two checks that are derivable — a story's own args must all
+ *   be exposed, and an args-consuming render must expose something — are below;
+ *   the rest is a review-time judgment.
+ * - **Rule 8 (mount-only props keyed to force a remount).** Not detectable
  *   statically; verified by hand in the Storybook UI.
  */
 
@@ -67,6 +67,29 @@ function getStories(mod: StoryModule): [string, Story][] {
       typeof value === 'object' &&
       value !== null,
   ) as [string, Story][];
+}
+
+/**
+ * Controls that render a click-to-reveal setter button ("Set boolean", "Set
+ * number", "Set object") instead of a widget when their arg is `undefined`.
+ * Meta must seed these so every panel opens with populated controls.
+ */
+const SETTER_BUTTON_CONTROLS = new Set(['boolean', 'number', 'object']);
+
+/** `control` is either a shorthand string, an object with a `type`, or `false`. */
+function controlType(argType: unknown): string | undefined {
+  const { control } = (argType ?? {}) as { control?: unknown };
+
+  if (typeof control === 'string') {
+    return control;
+  }
+
+  if (control && typeof control === 'object') {
+    const { type } = control as { type?: unknown };
+    return typeof type === 'string' ? type : undefined;
+  }
+
+  return undefined;
 }
 
 /**
@@ -116,6 +139,61 @@ describe.each(componentStories)('$path', ({ mod }) => {
     expect(unreachable).toEqual([]);
   });
 
+  it('seeds every knob whose control would otherwise need a click', () => {
+    // Storybook's BooleanControl/NumberControl/ObjectControl render a "Set …"
+    // button while their value is `undefined`, so an unseeded knob costs a click
+    // before it can be used. Where `undefined` is a meaningful state, the knob
+    // models it as an explicit option (`auto`) rather than staying unset — see
+    // `showSwipeHandle` in drawer and `role` in alert.
+    const argTypes = mod.default?.argTypes ?? {};
+    const args = (mod.default?.args ?? {}) as Record<string, unknown>;
+
+    const unseeded = Object.entries(argTypes)
+      .filter(([, argType]) =>
+        SETTER_BUTTON_CONTROLS.has(controlType(argType) ?? ''),
+      )
+      .filter(([prop]) => args[prop] === undefined)
+      .map(([prop]) => prop);
+
+    expect(unseeded).toEqual([]);
+  });
+
+  it('exposes every prop a story pins in its own args', () => {
+    // A story's own args are what it is demonstrating, so they belong in its
+    // controls — otherwise the reader cannot tell what makes the story different.
+    const offenders = stories
+      .filter(([name]) => name !== 'Default')
+      .flatMap(([name, story]) => {
+        const include = story.parameters?.controls?.include;
+
+        if (!Array.isArray(include)) {
+          return [];
+        }
+
+        return Object.keys(story.args ?? {})
+          .filter((prop) => !include.includes(prop))
+          .map((prop) => `${name}: ${prop}`);
+      });
+
+    expect(offenders).toEqual([]);
+  });
+
+  it('leaves no args-consuming story without a control', () => {
+    // A render that takes `args` has something live to expose; pairing it with
+    // an empty `include` produces a dead controls panel. A story that genuinely
+    // fixes everything should take no args at all.
+    const dead = stories
+      .filter(([name]) => name !== 'Default')
+      .filter(([, story]) => (renderArity(story) ?? 0) > 0)
+      .filter(([, story]) => {
+        const include = story.parameters?.controls?.include;
+        return Array.isArray(include) && include.length === 0;
+      })
+      .map(([name]) => name);
+
+    expect(dead).toEqual([]);
+  });
+
   it('narrows controls on every non-Default story', () => {
     const offenders = stories
       .filter(([name]) => name !== 'Default')
@@ -145,7 +223,7 @@ describe.each(componentStories)('$path', ({ mod }) => {
   });
 
   it('documents the controlled counterpart of every uncontrolled default', () => {
-    // Rule 7: if `defaultChecked` is a knob, `checked` must at least be a
+    // Rule 8: if `defaultChecked` is a knob, `checked` must at least be a
     // docs-only row — consumers need to know the controlled prop exists.
     const argTypes = mod.default?.argTypes ?? {};
     const missing = Object.keys(argTypes)

--- a/tests/story-controls.test.ts
+++ b/tests/story-controls.test.ts
@@ -3,29 +3,15 @@ import { describe, expect, it } from 'vitest';
 
 /**
  * Guards the Storybook controls convention documented in
- * `.claude/skills/nebari-component/SKILL.md` Step 3.
+ * `.claude/skills/nebari-component/SKILL.md` Step 3. Storybook's react-docgen
+ * surfaces nothing beyond what a story declares — meta `argTypes` *is* the props
+ * table — so without this test a missing `controls.include` or a typo in an
+ * `include` list fails silently.
  *
- * This matters because Storybook's react-docgen surfaces nothing beyond what a
- * story declares — meta `argTypes` *is* the props table. Without this test, a
- * new prop, a story missing `controls.include`, or a typo in an `include` list
- * all fail silently.
- *
- * Not covered here:
- * - **cva variant drift, and omitted props generally.** `cva()` does not expose
- *   its config at runtime and docgen yields nothing, so there is no source of
- *   truth for "the full prop surface" to diff against. A prop that is simply
- *   never declared cannot be detected. The uncontrolled/controlled pairing
- *   check below closes the one sub-case that has a derivable expectation.
- * - **Whether a render actually *uses* the args it receives.** Arity is
- *   checkable (below); use is not. A render taking `args` and ignoring them
- *   stays a review-time concern.
- * - **Whether an `include` list is the *right* set.** "Applicable to this
- *   story" depends on what the render hardcodes, which is not statically
- *   derivable. The two checks that are derivable — a story's own args must all
- *   be exposed, and an args-consuming render must expose something — are below;
- *   the rest is a review-time judgment.
- * - **Rule 8 (mount-only props keyed to force a remount).** Not detectable
- *   statically; verified by hand in the Storybook UI.
+ * Review-time concerns, not statically derivable: an omitted prop (`cva()` does
+ * not expose its config at runtime, so there is no full prop surface to diff
+ * against), whether a render *uses* the args it takes, whether an `include` list
+ * is the right set, and rule 8's remount keying.
  */
 
 type StoryModule = {
@@ -121,8 +107,7 @@ describe.each(componentStories)('$path', ({ mod }) => {
   });
 
   it('fixes no props in the Default playground args', () => {
-    // Rule 4: baseline meta args are fine, per-story args are not — they would
-    // pin a knob the playground is supposed to leave live.
+    // Baseline meta args are fine; per-story args would pin a live knob.
     const [, story] = stories.find(([name]) => name === 'Default') ?? [];
     expect(Object.keys(story?.args ?? {})).toEqual([]);
   });
@@ -140,11 +125,8 @@ describe.each(componentStories)('$path', ({ mod }) => {
   });
 
   it('seeds every knob whose control would otherwise need a click', () => {
-    // Storybook's BooleanControl/NumberControl/ObjectControl render a "Set …"
-    // button while their value is `undefined`, so an unseeded knob costs a click
-    // before it can be used. Where `undefined` is a meaningful state, the knob
-    // models it as an explicit option (`auto`) rather than staying unset — see
-    // `showSwipeHandle` in drawer and `role` in alert.
+    // Where `undefined` is itself a meaningful state, the knob models it as an
+    // explicit `auto` option — see `showSwipeHandle` in drawer, `role` in alert.
     const argTypes = mod.default?.argTypes ?? {};
     const args = (mod.default?.args ?? {}) as Record<string, unknown>;
 
@@ -159,8 +141,7 @@ describe.each(componentStories)('$path', ({ mod }) => {
   });
 
   it('exposes every prop a story pins in its own args', () => {
-    // A story's own args are what it is demonstrating, so they belong in its
-    // controls — otherwise the reader cannot tell what makes the story different.
+    // Otherwise the reader cannot tell what makes the story different.
     const offenders = stories
       .filter(([name]) => name !== 'Default')
       .flatMap(([name, story]) => {
@@ -179,9 +160,7 @@ describe.each(componentStories)('$path', ({ mod }) => {
   });
 
   it('leaves no args-consuming story without a control', () => {
-    // A render that takes `args` has something live to expose; pairing it with
-    // an empty `include` produces a dead controls panel. A story that genuinely
-    // fixes everything should take no args at all.
+    // A story that genuinely fixes everything should take no args at all.
     const dead = stories
       .filter(([name]) => name !== 'Default')
       .filter(([, story]) => (renderArity(story) ?? 0) > 0)
@@ -223,8 +202,7 @@ describe.each(componentStories)('$path', ({ mod }) => {
   });
 
   it('documents the controlled counterpart of every uncontrolled default', () => {
-    // Rule 8: if `defaultChecked` is a knob, `checked` must at least be a
-    // docs-only row — consumers need to know the controlled prop exists.
+    // Consumers need to know the controlled prop exists.
     const argTypes = mod.default?.argTypes ?? {};
     const missing = Object.keys(argTypes)
       .map((key) => /^default([A-Z]\w*)$/.exec(key))

--- a/tests/story-controls.test.ts
+++ b/tests/story-controls.test.ts
@@ -8,10 +8,14 @@ import { describe, expect, it } from 'vitest';
  * table — so without this test a missing `controls.include` or a typo in an
  * `include` list fails silently.
  *
+ * `Default` is the only playground: it exposes the full prop surface, and every
+ * other story narrows to `include: []` unless it declares its own story-only
+ * `argTypes`.
+ *
  * Review-time concerns, not statically derivable: an omitted prop (`cva()` does
  * not expose its config at runtime, so there is no full prop surface to diff
- * against), whether a render *uses* the args it takes, whether an `include` list
- * is the right set, and rule 8's remount keying.
+ * against), whether a render *uses* the args it takes, and rule 8's remount
+ * keying.
  */
 
 type StoryModule = {
@@ -78,16 +82,8 @@ function controlType(argType: unknown): string | undefined {
   return undefined;
 }
 
-/**
- * `controls.include` is matched by Storybook against `argType.name || key`. No
- * story sets a custom `name`, so comparing keys is correct — revisit if one does.
- */
-function documentedProps(mod: StoryModule, story: Story): Set<string> {
-  return new Set([
-    ...Object.keys(mod.default?.argTypes ?? {}),
-    ...Object.keys(story.argTypes ?? {}),
-  ]);
-}
+/** Radio widgets are not used; every union is a `select`. */
+const BANNED_CONTROLS = new Set(['radio', 'inline-radio']);
 
 it('finds every component story', () => {
   // Fails loudly if the glob breaks rather than silently asserting nothing.
@@ -140,39 +136,6 @@ describe.each(componentStories)('$path', ({ mod }) => {
     expect(unseeded).toEqual([]);
   });
 
-  it('exposes every prop a story pins in its own args', () => {
-    // Otherwise the reader cannot tell what makes the story different.
-    const offenders = stories
-      .filter(([name]) => name !== 'Default')
-      .flatMap(([name, story]) => {
-        const include = story.parameters?.controls?.include;
-
-        if (!Array.isArray(include)) {
-          return [];
-        }
-
-        return Object.keys(story.args ?? {})
-          .filter((prop) => !include.includes(prop))
-          .map((prop) => `${name}: ${prop}`);
-      });
-
-    expect(offenders).toEqual([]);
-  });
-
-  it('leaves no args-consuming story without a control', () => {
-    // A story that genuinely fixes everything should take no args at all.
-    const dead = stories
-      .filter(([name]) => name !== 'Default')
-      .filter(([, story]) => (renderArity(story) ?? 0) > 0)
-      .filter(([, story]) => {
-        const include = story.parameters?.controls?.include;
-        return Array.isArray(include) && include.length === 0;
-      })
-      .map(([name]) => name);
-
-    expect(dead).toEqual([]);
-  });
-
   it('narrows controls on every non-Default story', () => {
     const offenders = stories
       .filter(([name]) => name !== 'Default')
@@ -184,21 +147,45 @@ describe.each(componentStories)('$path', ({ mod }) => {
     expect(offenders).toEqual([]);
   });
 
-  it('only includes props that are documented in argTypes', () => {
-    const unknownProps = stories.flatMap(([name, story]) => {
-      const include = story.parameters?.controls?.include;
-      if (!Array.isArray(include)) {
-        return [];
-      }
+  it('shows only controls that belong to the story exclusively', () => {
+    // Meta argTypes are the `Default` playground's surface. A non-Default story
+    // may expose a knob only if it declares that knob itself.
+    const shared = stories
+      .filter(([name]) => name !== 'Default')
+      .flatMap(([name, story]) => {
+        const include = story.parameters?.controls?.include;
 
-      const documented = documentedProps(mod, story);
-      return include
-        .filter((prop): prop is string => typeof prop === 'string')
-        .filter((prop) => !documented.has(prop))
-        .map((prop) => `${name}: ${prop}`);
-    });
+        if (!Array.isArray(include)) {
+          return [];
+        }
 
-    expect(unknownProps).toEqual([]);
+        const own = new Set(Object.keys(story.argTypes ?? {}));
+        return include
+          .filter((prop): prop is string => typeof prop === 'string')
+          .filter((prop) => !own.has(prop))
+          .map((prop) => `${name}: ${prop}`);
+      });
+
+    expect(shared).toEqual([]);
+  });
+
+  it('uses no radio controls', () => {
+    const radios = [
+      ...Object.entries(mod.default?.argTypes ?? {}).map(
+        ([prop, argType]) => ['meta', prop, argType] as const,
+      ),
+      ...stories.flatMap(([name, story]) =>
+        Object.entries(story.argTypes ?? {}).map(
+          ([prop, argType]) => [name, prop, argType] as const,
+        ),
+      ),
+    ]
+      .filter(([, , argType]) =>
+        BANNED_CONTROLS.has(controlType(argType) ?? ''),
+      )
+      .map(([owner, prop]) => `${owner}: ${prop}`);
+
+    expect(radios).toEqual([]);
   });
 
   it('documents the controlled counterpart of every uncontrolled default', () => {

--- a/tests/story-controls.test.ts
+++ b/tests/story-controls.test.ts
@@ -1,0 +1,173 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Guards the Storybook controls convention documented in
+ * `.claude/skills/nebari-component/SKILL.md` Step 3.
+ *
+ * This matters because Storybook's react-docgen surfaces nothing beyond what a
+ * story declares — meta `argTypes` *is* the props table. Without this test, a
+ * new prop, a story missing `controls.include`, or a typo in an `include` list
+ * all fail silently.
+ *
+ * Not covered here:
+ * - **cva variant drift, and omitted props generally.** `cva()` does not expose
+ *   its config at runtime and docgen yields nothing, so there is no source of
+ *   truth for "the full prop surface" to diff against. A prop that is simply
+ *   never declared cannot be detected. The uncontrolled/controlled pairing
+ *   check below closes the one sub-case that has a derivable expectation.
+ * - **Whether a render actually *uses* the args it receives.** Arity is
+ *   checkable (below); use is not. A render taking `args` and ignoring them
+ *   stays a review-time concern.
+ * - **The inverse — a fixed showcase reading args it cannot expose.** Not
+ *   separable from the legitimate case: a `controls.include: []` showcase may
+ *   still spread baseline meta args into each hardcoded instance (see
+ *   `Variants` in `stories/button.stories.tsx`), which is the documented
+ *   pattern. Arity cannot distinguish the two.
+ * - **Rule 7 (mount-only props keyed to force a remount).** Not detectable
+ *   statically; verified by hand in the Storybook UI.
+ */
+
+type StoryModule = {
+  default?: Meta<unknown>;
+  [name: string]: unknown;
+};
+
+const modules = import.meta.glob<StoryModule>('../stories/*.stories.tsx', {
+  eager: true,
+});
+
+/** Only `Components/*` stories follow the convention; Foundations pages don't. */
+const componentStories = Object.entries(modules)
+  .map(([path, mod]) => ({ path: path.replace('../', ''), mod }))
+  .filter(({ mod }) => mod.default?.title?.startsWith('Components/'))
+  .sort((a, b) => a.path.localeCompare(b.path));
+
+type Story = StoryObj<unknown> & {
+  args?: Record<string, unknown>;
+  argTypes?: Record<string, unknown>;
+  render?: (...args: unknown[]) => unknown;
+  parameters?: { controls?: { include?: unknown } };
+};
+
+/**
+ * A `render` declared as `() => …` cannot receive args, so any control the story
+ * exposes is unreachable. `undefined` means the component renders with args
+ * directly, which is always fine.
+ */
+function renderArity(story: Story): number | undefined {
+  return typeof story.render === 'function' ? story.render.length : undefined;
+}
+
+function getStories(mod: StoryModule): [string, Story][] {
+  return Object.entries(mod).filter(
+    ([name, value]) =>
+      name !== 'default' &&
+      name !== '__namedExportsOrder' &&
+      typeof value === 'object' &&
+      value !== null,
+  ) as [string, Story][];
+}
+
+/**
+ * `controls.include` is matched by Storybook against `argType.name || key`. No
+ * story sets a custom `name`, so comparing keys is correct — revisit if one does.
+ */
+function documentedProps(mod: StoryModule, story: Story): Set<string> {
+  return new Set([
+    ...Object.keys(mod.default?.argTypes ?? {}),
+    ...Object.keys(story.argTypes ?? {}),
+  ]);
+}
+
+it('finds every component story', () => {
+  // Fails loudly if the glob breaks rather than silently asserting nothing.
+  expect(componentStories.length).toBeGreaterThanOrEqual(23);
+});
+
+describe.each(componentStories)('$path', ({ mod }) => {
+  const stories = getStories(mod);
+
+  it('exports a Default playground', () => {
+    expect(stories.map(([name]) => name)).toContain('Default');
+  });
+
+  it('leaves the Default playground controls unnarrowed', () => {
+    const [, story] = stories.find(([name]) => name === 'Default') ?? [];
+    expect(story?.parameters?.controls).toBeUndefined();
+  });
+
+  it('fixes no props in the Default playground args', () => {
+    // Rule 4: baseline meta args are fine, per-story args are not — they would
+    // pin a knob the playground is supposed to leave live.
+    const [, story] = stories.find(([name]) => name === 'Default') ?? [];
+    expect(Object.keys(story?.args ?? {})).toEqual([]);
+  });
+
+  it('routes every exposed control into the render', () => {
+    const unreachable = stories
+      .filter(([, story]) => {
+        const include = story.parameters?.controls?.include;
+        return Array.isArray(include) && include.length > 0;
+      })
+      .filter(([, story]) => renderArity(story) === 0)
+      .map(([name]) => name);
+
+    expect(unreachable).toEqual([]);
+  });
+
+  it('narrows controls on every non-Default story', () => {
+    const offenders = stories
+      .filter(([name]) => name !== 'Default')
+      .filter(
+        ([, story]) => !Array.isArray(story.parameters?.controls?.include),
+      )
+      .map(([name]) => name);
+
+    expect(offenders).toEqual([]);
+  });
+
+  it('only includes props that are documented in argTypes', () => {
+    const unknownProps = stories.flatMap(([name, story]) => {
+      const include = story.parameters?.controls?.include;
+      if (!Array.isArray(include)) {
+        return [];
+      }
+
+      const documented = documentedProps(mod, story);
+      return include
+        .filter((prop): prop is string => typeof prop === 'string')
+        .filter((prop) => !documented.has(prop))
+        .map((prop) => `${name}: ${prop}`);
+    });
+
+    expect(unknownProps).toEqual([]);
+  });
+
+  it('documents the controlled counterpart of every uncontrolled default', () => {
+    // Rule 7: if `defaultChecked` is a knob, `checked` must at least be a
+    // docs-only row — consumers need to know the controlled prop exists.
+    const argTypes = mod.default?.argTypes ?? {};
+    const missing = Object.keys(argTypes)
+      .map((key) => /^default([A-Z]\w*)$/.exec(key))
+      .filter((match): match is RegExpExecArray => match !== null)
+      .map(([, suffix]) => suffix[0].toLowerCase() + suffix.slice(1))
+      .filter((counterpart) => !(counterpart in argTypes));
+
+    expect(missing).toEqual([]);
+  });
+
+  it('describes every prop left visible in the props table', () => {
+    const argTypes = (mod.default?.argTypes ?? {}) as Record<
+      string,
+      { description?: string; table?: { disable?: boolean } }
+    >;
+
+    const undocumented = Object.entries(argTypes)
+      .filter(([, argType]) => argType?.table?.disable !== true)
+      .filter(([, argType]) => !argType?.description?.trim())
+      .map(([prop]) => prop);
+
+    expect(undocumented).toEqual([]);
+  });
+});


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://nebari.dev/community
-->

## Reference Issues or PRs

fixes #117
No functionality changes. This is a refactor to Unify the sotrybook control patters

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create a link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

## What does this implement/fix?

One Storybook controls convention across all 23 `Components/*` stories. `Default` is the
interactive playground (meta `argTypes` declare the prop surface, knobs stay live); every
other story narrows its panel with `parameters.controls.include`. 10 stories previously had
no `argTypes` at all, and showcase stories inherited knobs they hardcode or ignore.

Also removes knobs that silently did nothing: Storybook re-renders without remounting, so
mount-only props (`defaultChecked`, `defaultValue`, `defaultOpen`) now key the component to
force a remount, and controlled counterparts (`checked`, `value`, `open`) are docs-only rows.
Fixes two inaccurate descriptions along the way — dialog's `modal` and the "hollow" disabled
checkbox/radio wording.

_Put a `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [x] Documentation Update
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [ ] Other (please describe):

## Testing

- [x] Did you test the pull request locally?
- [ ] Did you add new tests?

## Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Nebari Internals docs.
  - If no docs exist:
    - Create a stub for documentation, including bullet points for how to use the feature, code snippets (including from
      happy path tests), etc.
We want to ensure that the content produced for Nebari is accessible; if you are making significant contributions,
please address the access-centred guidelines in your content and complete our checklist. Thanks to @isabela-pf for this checklist :)
-->

### Access-centered content checklist

#### Text styling

- [ ] The content is written with [plain language](https://www.plainlanguage.gov/guidelines/) (where relevant).
- [ ] If there are headers, they use the proper header tags (with only one level-one header: `H1` or `#` in markdown).
- [ ] All links describe where they link to (for example, check the [Nebari website](https://nebari.dev/)).
- [ ] This content adheres to the Nebari style guides.

#### Non-text content

- [ ] All content is represented as text (for example, images need alt text, and videos need captions or descriptive transcripts).
- [ ] If there are emojis, there are not more than three in a row.
- [ ] Don't use [flashing GIFs or videos](https://www.w3.org/TR/UNDERSTANDING-WCAG20/seizure-does-not-violate.html).
- [ ] If the content were to be read as plain text, it still makes sense, and no information is missing.

## Any other comments?

<!--
Please be aware that we are a loose team of volunteers, so patience is necessary;
assistance handling other issues is very welcome.
We value all user contributions. If we are slow to review, either the pull request needs some benchmarking, tinkering,
convincing, etc., or the reviewers are likely busy. In either case,
we ask for your understanding during the
review process.
Thanks for contributing to Nebari 🙏🏼!
-->
