### PR TITLE
Fix tab styling.

### DIFF
--- a/registry/nebari/ui/tabs.tsx
+++ b/registry/nebari/ui/tabs.tsx
@@ -27,11 +27,11 @@ const tabsTabVariants = cva(
   {
     variants: {
       variant: {
-        pill: 'h-[calc(100%-1px)] rounded-sm border border-border bg-card px-2 py-1 data-[active]:border-border-strong data-[active]:shadow-[0_1px_1.5px_rgb(0_0_0_/_0.1)] data-[disabled]:bg-muted data-[orientation=vertical]:h-8',
+        pill: 'h-[calc(100%-1px)] rounded-sm border border-transparent px-2 py-1 data-[active]:border-border-strong data-[active]:bg-card data-[active]:shadow-[0_1px_1.5px_rgb(0_0_0_/_0.1)] data-[disabled]:bg-muted data-[orientation=vertical]:h-8',
         underline: 'rounded-none px-0 pb-2',
         line: 'rounded-none px-0 pb-2',
         toggle:
-          'h-[calc(100%-1px)] rounded-sm border border-border bg-card px-2 py-1 data-[active]:border-border-strong data-[active]:shadow-[0_1px_1.5px_rgb(0_0_0_/_0.1)] data-[disabled]:bg-muted data-[orientation=vertical]:h-8',
+          'h-[calc(100%-1px)] rounded-sm border border-transparent px-2 py-1 data-[active]:border-border-strong data-[active]:bg-card data-[active]:shadow-[0_1px_1.5px_rgb(0_0_0_/_0.1)] data-[disabled]:bg-muted data-[orientation=vertical]:h-8',
       },
     },
     defaultVariants: {

--- a/stories/tabs.stories.tsx
+++ b/stories/tabs.stories.tsx
@@ -22,7 +22,7 @@ const meta = {
     docs: {
       description: {
         component:
-          'Tabs switch between related panels. Base UI provides keyboard navigation, `aria-selected`, and panel association; Nebari provides bordered pill and underline visual variants.',
+          'Tabs switch between related panels. Base UI provides keyboard navigation, `aria-selected`, and panel association; Nebari provides pill (active tab outlined) and underline visual variants.',
       },
     },
   },
@@ -36,7 +36,7 @@ const meta = {
   argTypes: {
     variant: {
       description:
-        'Visual style, set on `TabsList` and propagated to `TabsTab` and `TabsIndicator` through context. `pill` is a bordered card-colored pill; `underline` and `line` use an underline indicator; `toggle` renders a segmented control.',
+        'Visual style, set on `TabsList` and propagated to `TabsTab` and `TabsIndicator` through context. `pill` outlines only the active tab as a bordered card-colored pill; `underline` and `line` use an underline indicator; `toggle` renders a segmented control.',
       control: 'select',
       options: ['pill', 'underline', 'line', 'toggle'],
       table: { defaultValue: { summary: 'pill' } },
@@ -174,7 +174,7 @@ export const Default: Story = {
     docs: {
       description: {
         story:
-          'The default pill style. Each tab is a bordered card-colored pill; disabled pills keep the same sizing and switch to the muted background. Use the controls to preview every variant, orientation, and the icon and disabled states.',
+          'The default pill style. Only the active tab renders as a bordered card-colored pill; inactive tabs are plain text. Disabled pills keep the same sizing and switch to the muted background. Use the controls to preview every variant, orientation, and the icon and disabled states.',
       },
     },
   },

--- a/tests/tabs.test.tsx
+++ b/tests/tabs.test.tsx
@@ -124,8 +124,15 @@ describe('Tabs', () => {
       'h-[calc(100%-1px)]',
     );
     expect(tabsTabVariants({ variant: 'pill' })).toContain('rounded-sm');
-    expect(tabsTabVariants({ variant: 'pill' })).toContain('border-border');
-    expect(tabsTabVariants({ variant: 'pill' })).toContain('bg-card');
+    expect(tabsTabVariants({ variant: 'pill' })).toContain(
+      'border-transparent',
+    );
+    expect(tabsTabVariants({ variant: 'pill' })).toContain(
+      'data-[active]:border-border-strong',
+    );
+    expect(tabsTabVariants({ variant: 'pill' })).toContain(
+      'data-[active]:bg-card',
+    );
     expect(tabsTabVariants({ variant: 'pill' })).toContain('px-2');
     expect(tabsTabVariants({ variant: 'pill' })).toContain('py-1');
     expect(tabsTabVariants({ variant: 'pill' })).toContain(
@@ -144,7 +151,9 @@ describe('Tabs', () => {
     expect(tabsListVariants({ variant: 'line' })).toContain('border-b');
     expect(tabsListVariants({ variant: 'toggle' })).toContain('bg-background');
     expect(tabsTabVariants({ variant: 'toggle' })).toContain('rounded-sm');
-    expect(tabsTabVariants({ variant: 'toggle' })).toContain('bg-card');
+    expect(tabsTabVariants({ variant: 'toggle' })).toContain(
+      'data-[active]:bg-card',
+    );
     expect(tabsTabVariants({ variant: 'toggle' })).toContain(
       'data-[active]:shadow-[0_1px_1.5px_rgb(0_0_0_/_0.1)]',
     );


### PR DESCRIPTION
Fixes incorrect inactive tab styling.

## Reference Issues or PRs

<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create a link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

## What does this implement/fix?

_Put a `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds a feature)
- [ ] Breaking change (fix or feature that would cause existing features not to work as expected)
- [ ] Documentation Update
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build related changes
- [x] Other (please describe):

## Testing

- [x] Did you test the pull request locally?
- [x] Did you add new tests?

## Documentation

<!--
  Where is this feature or API documented?

  - If docs exist:
    - Update any references, if relevant. This includes Guides and Nebari Internals docs.
  - If no docs exist:
    - Create a stub for documentation, including bullet points for how to use the feature, code snippets (including from
      happy path tests), etc.
We want to ensure that the content produced for Nebari is accessible; if you are making significant contributions,
please address the access-centred guidelines in your content and complete our checklist. Thanks to @isabela-pf for this checklist :)
-->

### Access-centered content checklist

#### Text styling

- [ ] The content is written with [plain language](https://www.plainlanguage.gov/guidelines/) (where relevant).
- [ ] If there are headers, they use the proper header tags (with only one level-one header: `H1` or `#` in markdown).
- [ ] All links describe where they link to (for example, check the [Nebari website](https://nebari.dev/)).
- [ ] This content adheres to the Nebari style guides.

#### Non-text content

- [ ] All content is represented as text (for example, images need alt text, and videos need captions or descriptive transcripts).
- [ ] If there are emojis, there are not more than three in a row.
- [ ] Don't use [flashing GIFs or videos](https://www.w3.org/TR/UNDERSTANDING-WCAG20/seizure-does-not-violate.html).
- [ ] If the content were to be read as plain text, it still makes sense, and no information is missing.

## Any other comments?

<!--
Please be aware that we are a loose team of volunteers, so patience is necessary;
assistance handling other issues is very welcome.
We value all user contributions. If we are slow to review, either the pull request needs some benchmarking, tinkering,
convincing, etc., or the reviewers are likely busy. In either case,
we ask for your understanding during the
review process.
Thanks for contributing to Nebari 🙏🏼!
-->
