### PR TITLE
Make `shadcn add @nebari/theme` idempotent against an existing stylesheet

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,7 @@ registry/nebari/
   ui/<name>.tsx        # components (kebab-case filenames)
   hooks/<name>.ts      # shared non-visual logic (registry:hook)
   lib/utils.ts         # cn() helper
-  globals.css          # theme: semantic CSS-variable tokens, light + .dark
+  globals.css          # theme source of truth: primitives + semantic tokens (light/.dark) + @theme inline
   skills/nebari-ui/    # CONSUMER skill, shipped via the registry (claude-skill item)
 stories/<name>.stories.tsx   # Storybook stories — top-level, NOT co-located
 tests/<name>.test.tsx        # Vitest tests — top-level, NOT co-located
@@ -161,7 +161,16 @@ rules that are easy to get wrong:
 - **New tokens** go in `globals.css` as semantic CSS variables for *both* light
   and dark — don't invent a token unless a design genuinely needs one. The OKLCH
   brand scale mirrors the Figma variables; keep code and Figma in sync rather
-  than free-handing colors.
+  than free-handing colors. Semantic values are literal oklch with the primitive
+  named in a trailing comment (the shadcn CLI can only ship literals), exposed to
+  Tailwind via `--color-<name>: var(--<name>)` in `@theme inline`.
+- **`globals.css` is the CLI's canonical output.** Keep exactly one `:root`,
+  one `.dark`, and one `@theme inline` (which also holds fonts, radius steps,
+  motion tokens, and `@keyframes`) — that is the shape `shadcn add` writes, so
+  re-applying `@nebari/theme` to it is a no-op (#151). The `theme` item in
+  `registry.json` is *derived* from this file: after editing tokens run
+  `bun run sync:theme`. `tests/theme.test.ts` fails on drift and runs the real
+  CLI against a throwaway consumer to prove the apply is idempotent.
 - **Fonts** (`Geist`, `IBM Plex Mono`) are referenced by tokens but not shipped
   to consumers; the consumer skill documents installing the `@fontsource`
   packages.
@@ -206,10 +215,10 @@ Once you've decided a component should move, follow these rules:
   component's `cva` block. Re-enumerate every transition property explicitly
   (e.g. `transition-[color,background-color,transform]`) so nothing is
   silently dropped.
-- **Adding new motion tokens.** New `@keyframes` or timing variables go in
-  `globals.css` (`:root` for vars, top-level for keyframes) **and** in the
-  `theme` item in `registry.json` (`css` for keyframes, `cssVars.theme` for
-  vars) so `shadcn add @nebari/theme` ships them to consumers.
+- **Adding new motion tokens.** New `@keyframes` and timing variables go in
+  `globals.css` **inside `@theme inline`** — the shadcn CLI writes keyframes
+  there and deduplicates only there — then run `bun run sync:theme` to
+  regenerate the `theme` item so `shadcn add @nebari/theme` ships them.
 - **JS animation.** Use the Motion library via Base UI's `render` prop as the
   escape hatch when CSS transitions are insufficient. Do not add Motion as a
   default `dependency` in any `registry.json` entry.

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ flow as the components themselves.
 | `registry/nebari/ui/`         | UI components (`registry:ui`).                                     |
 | `registry/nebari/hooks/`      | Shared non-visual logic, e.g. theme state (`registry:hook`).       |
 | `registry/nebari/lib/`        | Shared library code, including the `cn()` helper (`registry:lib`). |
-| `registry/nebari/globals.css` | Tailwind v4 `@theme` token mapping.                                |
+| `registry/nebari/globals.css` | Theme source of truth; `bun run sync:theme` derives the item.     |
 | `registry/nebari/skills/`     | Consumer-facing Claude Code skills (`registry:file`).              |
 | `public/r/`                   | Built, installable JSON artifacts produced by `build:registry`.    |
 

--- a/bun.lock
+++ b/bun.lock
@@ -35,6 +35,7 @@
         "@vitest/coverage-v8": "4.1.11",
         "jsdom": "^30.0.1",
         "playwright": "1.62.1",
+        "postcss": "8.5.15",
         "shadcn": "4.19.0",
         "storybook": "^10.5.0",
         "tailwindcss": "^4.1.13",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "storybook": "storybook dev -p 6006",
     "test:storybook": "vitest run --project=storybook",
     "build:storybook": "storybook build -o public",
-    "build:pages": "bun run build:storybook && bun run build:registry"
+    "build:pages": "bun run build:storybook && bun run build:registry",
+    "sync:theme": "bun run scripts/sync-theme.ts && biome format --write registry.json"
   },
   "dependencies": {
     "@base-ui/react": "^1.6.0",
@@ -54,6 +55,7 @@
     "@vitest/coverage-v8": "4.1.11",
     "jsdom": "^30.0.1",
     "playwright": "1.62.1",
+    "postcss": "8.5.15",
     "shadcn": "4.19.0",
     "storybook": "^10.5.0",
     "tailwindcss": "^4.1.13",

--- a/registry.json
+++ b/registry.json
@@ -589,30 +589,161 @@
       "title": "Nebari theme",
       "description": "Nebari brand color tokens and radius for light and dark modes.",
       "css": {
+        ":root": {
+          "--primary-magenta-50": "oklch(97.93% 0.0118 313.22)",
+          "--primary-magenta-100": "oklch(95.07% 0.0323 311.75)",
+          "--primary-magenta-200": "oklch(86.93% 0.0881 311.32)",
+          "--primary-magenta-300": "oklch(77.96% 0.1496 311.14)",
+          "--primary-magenta-400": "oklch(69.98% 0.1926 311.48)",
+          "--primary-magenta-500": "oklch(61.98% 0.2159 311.67)",
+          "--primary-magenta-600": "oklch(55.06% 0.1886 311.45)",
+          "--primary-magenta-700": "oklch(47.01% 0.1577 311.26)",
+          "--primary-magenta-800": "oklch(39.93% 0.1238 311.55)",
+          "--primary-magenta-900": "oklch(32.97% 0.0867 312.00)",
+          "--primary-magenta-950": "oklch(27.03% 0.0852 311.77)",
+          "--accent-teal-50": "oklch(97.94% 0.0160 187.35)",
+          "--accent-teal-100": "oklch(95.02% 0.0407 187.03)",
+          "--accent-teal-200": "oklch(86.97% 0.0671 187.76)",
+          "--accent-teal-300": "oklch(77.96% 0.0893 187.30)",
+          "--accent-teal-400": "oklch(69.9% 0.0995 187.56)",
+          "--accent-teal-500": "oklch(61.96% 0.0932 187.62)",
+          "--accent-teal-600": "oklch(55.09% 0.0808 187.38)",
+          "--accent-teal-700": "oklch(47% 0.0677 188.28)",
+          "--accent-teal-800": "oklch(39.98% 0.0539 188.08)",
+          "--accent-teal-900": "oklch(33.02% 0.0392 187.72)",
+          "--accent-teal-950": "oklch(27.14% 0.0398 187.08)",
+          "--highlight-yellow-50": "oklch(98.03% 0.0183 86.15)",
+          "--highlight-yellow-100": "oklch(94.96% 0.0461 86.46)",
+          "--highlight-yellow-200": "oklch(87.03% 0.0889 86.52)",
+          "--highlight-yellow-300": "oklch(77.95% 0.1259 85.96)",
+          "--highlight-yellow-400": "oklch(70.05% 0.1417 86.43)",
+          "--highlight-yellow-500": "oklch(62.04% 0.1267 87.01)",
+          "--highlight-yellow-600": "oklch(55.01% 0.1117 86.53)",
+          "--highlight-yellow-700": "oklch(46.93% 0.0960 86.63)",
+          "--highlight-yellow-800": "oklch(40.14% 0.0731 87.00)",
+          "--highlight-yellow-900": "oklch(32.9% 0.0514 85.56)",
+          "--highlight-yellow-950": "oklch(26.86% 0.0514 86.55)",
+          "--neutral-50": "oklch(97.94% 0.0013 286.38)",
+          "--neutral-100": "oklch(95.04% 0.0042 236.50)",
+          "--neutral-200": "oklch(87.02% 0.0106 247.95)",
+          "--neutral-300": "oklch(77.94% 0.0168 253.93)",
+          "--neutral-400": "oklch(70% 0.0253 250.17)",
+          "--neutral-500": "oklch(62.01% 0.0331 251.43)",
+          "--neutral-600": "oklch(54.87% 0.0393 252.47)",
+          "--neutral-700": "oklch(46.94% 0.0327 253.44)",
+          "--neutral-800": "oklch(40% 0.0269 250.57)",
+          "--neutral-900": "oklch(32.95% 0.0209 254.12)",
+          "--neutral-950": "oklch(26.95% 0.0219 254.20)",
+          "--zinc-50": "oklch(97.91% 0 0)",
+          "--zinc-100": "oklch(94.94% 0.0013 286.37)",
+          "--zinc-200": "oklch(87.08% 0.0041 286.31)",
+          "--zinc-300": "oklch(78.06% 0.0056 286.27)",
+          "--zinc-400": "oklch(69.88% 0.0130 286.06)",
+          "--zinc-500": "oklch(61.96% 0.0134 286.00)",
+          "--zinc-600": "oklch(54.86% 0.0154 285.88)",
+          "--zinc-700": "oklch(47.01% 0.0112 285.96)",
+          "--zinc-800": "oklch(39.94% 0.0066 286.10)",
+          "--zinc-900": "oklch(33.01% 0.0052 286.11)",
+          "--zinc-950": "oklch(26.94% 0.0037 286.15)",
+          "--zinc-975": "oklch(21.86% 0.0039 286.08)",
+          "--blue-50": "oklch(97.93% 0.0083 271.33)",
+          "--blue-100": "oklch(95.08% 0.0232 264.46)",
+          "--blue-200": "oklch(87.12% 0.0567 264.22)",
+          "--blue-300": "oklch(78.02% 0.0950 264.35)",
+          "--blue-400": "oklch(69.95% 0.1433 264.44)",
+          "--blue-500": "oklch(62.1% 0.1880 264.30)",
+          "--blue-600": "oklch(55.04% 0.2158 264.34)",
+          "--blue-700": "oklch(47.06% 0.2174 264.33)",
+          "--blue-800": "oklch(40.02% 0.1811 264.47)",
+          "--blue-900": "oklch(33.01% 0.1387 264.40)",
+          "--blue-950": "oklch(27.02% 0.0864 264.19)",
+          "--green-50": "oklch(97.94% 0.0182 150.56)",
+          "--green-100": "oklch(94.94% 0.0433 149.41)",
+          "--green-200": "oklch(87.04% 0.0814 149.55)",
+          "--green-300": "oklch(78.09% 0.1374 149.53)",
+          "--green-400": "oklch(69.96% 0.1814 149.67)",
+          "--green-500": "oklch(61.95% 0.1718 149.70)",
+          "--green-600": "oklch(55.08% 0.1525 149.53)",
+          "--green-700": "oklch(47.01% 0.1313 149.41)",
+          "--green-800": "oklch(40.02% 0.1082 149.72)",
+          "--green-900": "oklch(32.88% 0.0887 149.73)",
+          "--green-950": "oklch(27.13% 0.0631 149.76)",
+          "--red-50": "oklch(97.91% 0.0087 26.02)",
+          "--red-100": "oklch(95.06% 0.0247 29.93)",
+          "--red-200": "oklch(86.96% 0.0594 27.38)",
+          "--red-300": "oklch(78.02% 0.1024 27.78)",
+          "--red-400": "oklch(69.96% 0.1660 27.34)",
+          "--red-500": "oklch(62.07% 0.2077 27.48)",
+          "--red-600": "oklch(54.97% 0.2151 27.33)",
+          "--red-700": "oklch(46.91% 0.1900 27.40)",
+          "--red-800": "oklch(39.97% 0.1611 27.26)",
+          "--red-900": "oklch(33.1% 0.1332 27.42)",
+          "--red-950": "oklch(27.06% 0.0890 26.98)",
+          "--yellow-50": "oklch(97.95% 0.0179 89.36)",
+          "--yellow-100": "oklch(95.02% 0.0692 92.11)",
+          "--yellow-200": "oklch(87.09% 0.1248 91.93)",
+          "--yellow-300": "oklch(78.1% 0.1564 91.73)",
+          "--yellow-400": "oklch(69.92% 0.1414 91.77)",
+          "--yellow-500": "oklch(62.13% 0.1269 92.02)",
+          "--yellow-600": "oklch(54.88% 0.1114 91.56)",
+          "--yellow-700": "oklch(46.91% 0.0960 91.90)",
+          "--yellow-800": "oklch(40.15% 0.0821 92.02)",
+          "--yellow-900": "oklch(33.09% 0.0677 92.20)",
+          "--yellow-950": "oklch(26.96% 0.0539 91.43)",
+          "--black": "oklch(0% 0 0)",
+          "--white": "oklch(100% 0 0)",
+          "--foundation-black": "oklch(20.76% 0.0135 258.37)",
+          "--foundation-white": "oklch(100% 0 0)"
+        },
         "@keyframes nebari-fade-in": {
-          "from": { "opacity": "0" },
-          "to": { "opacity": "1" }
+          "from": {
+            "opacity": "0"
+          },
+          "to": {
+            "opacity": "1"
+          }
         },
         "@keyframes nebari-fade-out": {
-          "from": { "opacity": "1" },
-          "to": { "opacity": "0" }
+          "from": {
+            "opacity": "1"
+          },
+          "to": {
+            "opacity": "0"
+          }
         },
         "@keyframes nebari-slide-up-fade": {
-          "from": { "opacity": "0", "transform": "translateY(6px)" },
-          "to": { "opacity": "1", "transform": "translateY(0)" }
+          "from": {
+            "opacity": "0",
+            "transform": "translateY(6px)"
+          },
+          "to": {
+            "opacity": "1",
+            "transform": "translateY(0)"
+          }
         },
         "@keyframes nebari-slide-down-fade": {
-          "from": { "opacity": "1", "transform": "translateY(0)" },
-          "to": { "opacity": "0", "transform": "translateY(6px)" }
+          "from": {
+            "opacity": "1",
+            "transform": "translateY(0)"
+          },
+          "to": {
+            "opacity": "0",
+            "transform": "translateY(6px)"
+          }
         },
         "@keyframes nebari-skeleton-pulse": {
-          "0%, 100%": { "opacity": "1" },
-          "50%": { "opacity": "0.5" }
+          "0%, 100%": {
+            "opacity": "1"
+          },
+          "50%": {
+            "opacity": "0.5"
+          }
         }
       },
       "cssVars": {
         "theme": {
-          "radius": "0.625rem",
+          "font-sans": "'Geist Variable', ui-sans-serif, system-ui, sans-serif",
+          "font-mono": "'IBM Plex Mono', ui-monospace, SFMono-Regular, monospace",
           "duration-fast": "100ms",
           "duration-base": "200ms",
           "duration-slow": "350ms",
@@ -626,6 +757,7 @@
           "animate-skeleton-pulse": "nebari-skeleton-pulse var(--duration-loading) var(--ease-standard) infinite"
         },
         "light": {
+          "radius": "0.625rem",
           "background": "oklch(97.91% 0 0)",
           "foreground": "oklch(26.94% 0.0037 286.15)",
           "scrim": "rgba(0, 0, 0, 0.5)",

--- a/registry/nebari/globals.css
+++ b/registry/nebari/globals.css
@@ -9,12 +9,21 @@
  *      named to match Figma, with the source hex recorded for auditability.
  *      These are theme-independent and are NOT exposed as Tailwind utilities.
  *   2. Semantic     — role-based tokens (`--background`, `--primary`, …) that
- *      reference the primitives and switch with light/dark, following Figma's
- *      Light/Dark collections. These are what components consume.
+ *      switch with light/dark, following Figma's Light/Dark collections. These
+ *      are what components consume. Each value is the resolved oklch of a
+ *      primitive, named in the trailing comment.
  *
- * Keep this file and the `theme` item in `registry.json` in sync: the installable
- * theme ships the same semantic values (flattened to their resolved oklch).
+ * This file is the canonical output of `npx shadcn add @nebari/theme`: it has
+ * exactly the shape the shadcn CLI writes (one `:root`, one `.dark`, one
+ * `@theme inline` that also holds the motion tokens and `@keyframes`), so
+ * re-applying the theme to a stylesheet in this shape is a no-op apart from
+ * whitespace. That is also why the semantic values are literals rather than
+ * `var(--primitive)` references — the CLI can only ship literal values, and
+ * would rewrite references on every apply. `tests/theme.test.ts` derives the
+ * `theme` item in `registry.json` from this file and fails if the two drift;
+ * run `bun run sync:theme` after editing this file to regenerate the item.
  */
+
 :root {
   /* ── Primitives: Primary Magenta ─────────────────────────────────────── */
   --primary-magenta-50: oklch(97.93% 0.0118 313.22); /* #fbf6fe */
@@ -139,14 +148,12 @@
   --white: oklch(100% 0 0); /* #ffffff */
   --foundation-black: oklch(20.76% 0.0135 258.37); /* #14181e */
   --foundation-white: oklch(100% 0 0); /* #ffffff */
-}
 
-/*
- * Semantic tokens — Light (Figma "Light" collection). secondary/accent have no
- * Figma equivalent (Nebari uses a single magenta brand color), so they map to
- * the neutral ramp.
- */
-:root {
+  /*
+   * Semantic tokens — Light (Figma "Light" collection). secondary/accent have
+   * no Figma equivalent (Nebari uses a single magenta brand color), so they
+   * map to the neutral ramp.
+   */
   --radius: 0.625rem;
 
   /*
@@ -157,208 +164,150 @@
    * on pages painted with it. It is kept so existing consumers do not shift —
    * migrate uses to canvas, header, card, or muted.
    */
-  --background: var(--zinc-50);
-  --foreground: var(--zinc-950);
+  --background: oklch(97.91% 0 0); /* zinc-50 */
+  --foreground: oklch(26.94% 0.0037 286.15); /* zinc-950 */
   --scrim: rgba(0, 0, 0, 0.5);
 
   /* Layer 0 — PAGE. The app body. Use on every page root. Nothing sits below. */
-  --canvas: var(--white);
-  --canvas-foreground: var(--zinc-950);
+  --canvas: oklch(100% 0 0); /* white */
+  --canvas-foreground: oklch(26.94% 0.0037 286.15); /* zinc-950 */
 
   /* Layer 1 — CHROME. App furniture framing the page: top bar / MenuBar,
    * sidebar, toolbars, table head, sticky footer. Sits directly on canvas. */
-  --header: var(--zinc-50);
-  --header-foreground: var(--zinc-950);
+  --header: oklch(97.91% 0 0); /* zinc-50 */
+  --header-foreground: oklch(26.94% 0.0037 286.15); /* zinc-950 */
 
   /* Layer 2 — RAISED. Cards, panels, dialogs, sheets. In light mode this is
    * separated from canvas by border/default, NOT by fill. */
-  --card: var(--white);
-  --card-foreground: var(--zinc-950);
+  --card: oklch(100% 0 0); /* white */
+  --card-foreground: oklch(26.94% 0.0037 286.15); /* zinc-950 */
 
   /* Layer 2 — RAISED, FLOATING. Popovers, dropdowns, tooltips, comboboxes.
    * Same fill as card; differentiated by elevation shadow, not colour. */
-  --popover: var(--white);
-  --popover-foreground: var(--zinc-950);
+  --popover: oklch(100% 0 0); /* white */
+  --popover-foreground: oklch(26.94% 0.0037 286.15); /* zinc-950 */
 
-  --primary: var(--primary-magenta-600);
-  --primary-foreground: var(--white);
+  --primary: oklch(55.06% 0.1886 311.45); /* primary-magenta-600 */
+  --primary-foreground: oklch(100% 0 0); /* white */
   /* Figma color/background/primary-hover — hover/pressed fill. */
-  --primary-hover: var(--primary-magenta-700);
+  --primary-hover: oklch(47.01% 0.1577 311.26); /* primary-magenta-700 */
 
-  --secondary: var(--neutral-100);
-  --secondary-foreground: var(--neutral-900);
+  --secondary: oklch(95.04% 0.0042 236.50); /* neutral-100 */
+  --secondary-foreground: oklch(32.95% 0.0209 254.12); /* neutral-900 */
 
   /* Layer 3 — RECESSED. Only INSIDE a card or chrome: input fills, table zebra
    * rows, progress/slider tracks, disabled states. In dark mode recesses lift,
    * they do not dig. Muted text on this surface must use
    * `--muted-foreground-strong`, not `--muted-foreground`. */
-  --muted: var(--zinc-100);
-  --muted-foreground: var(--zinc-600);
+  --muted: oklch(94.94% 0.0013 286.37); /* zinc-100 */
+  --muted-foreground: oklch(54.86% 0.0154 285.88); /* zinc-600 */
   /* Figma color/foreground/muted-strong — pressed interactive text, and any
    * muted text sitting on `--muted`. */
-  --muted-foreground-strong: var(--zinc-700);
+  --muted-foreground-strong: oklch(47.01% 0.0112 285.96); /* zinc-700 */
 
-  --accent: var(--neutral-100);
-  --accent-foreground: var(--neutral-900);
+  --accent: oklch(95.04% 0.0042 236.50); /* neutral-100 */
+  --accent-foreground: oklch(32.95% 0.0209 254.12); /* neutral-900 */
 
   /* Feedback pairs: a soft background fill + a strong foreground for text and
    * borders. Mirrors Figma's color/background/* and color/foreground/* roles. */
-  --info: var(--blue-100);
-  --info-foreground: var(--blue-600);
+  --info: oklch(95.08% 0.0232 264.46); /* blue-100 */
+  --info-foreground: oklch(55.04% 0.2158 264.34); /* blue-600 */
 
-  --destructive: var(--red-100);
-  --destructive-foreground: var(--red-600);
+  --destructive: oklch(95.06% 0.0247 29.93); /* red-100 */
+  --destructive-foreground: oklch(54.97% 0.2151 27.33); /* red-600 */
 
-  --warning: var(--yellow-100);
-  --warning-foreground: var(--yellow-700);
+  --warning: oklch(95.02% 0.0692 92.11); /* yellow-100 */
+  --warning-foreground: oklch(46.91% 0.0960 91.90); /* yellow-700 */
 
-  --success: var(--green-100);
-  --success-foreground: var(--green-700);
+  --success: oklch(94.94% 0.0433 149.41); /* green-100 */
+  --success-foreground: oklch(47.01% 0.1313 149.41); /* green-700 */
 
-  --border: var(--zinc-300);
-  --input: var(--zinc-400);
+  --border: oklch(78.06% 0.0056 286.27); /* zinc-300 */
+  --input: oklch(69.88% 0.0130 286.06); /* zinc-400 */
   /* Figma color/border/strong — a stronger, more visible border than the
    * default (used by the Badge outline variant). */
-  --border-strong: var(--zinc-500);
-  --ring: var(--primary-magenta-500);
+  --border-strong: oklch(61.96% 0.0134 286.00); /* zinc-500 */
+  --ring: oklch(61.98% 0.2159 311.67); /* primary-magenta-500 */
 
-  --chart-1: var(--primary-magenta-500);
-  --chart-2: var(--accent-teal-500);
-  --chart-3: var(--highlight-yellow-400);
-  --chart-4: var(--blue-500);
-  --chart-5: var(--green-500);
+  --chart-1: oklch(61.98% 0.2159 311.67); /* primary-magenta-500 */
+  --chart-2: oklch(61.96% 0.0932 187.62); /* accent-teal-500 */
+  --chart-3: oklch(70.05% 0.1417 86.43); /* highlight-yellow-400 */
+  --chart-4: oklch(62.1% 0.1880 264.30); /* blue-500 */
+  --chart-5: oklch(61.95% 0.1718 149.70); /* green-500 */
 
-  --sidebar: var(--zinc-50);
-  --sidebar-foreground: var(--zinc-950);
-  --sidebar-primary: var(--primary-magenta-600);
-  --sidebar-primary-foreground: var(--white);
-  --sidebar-accent: var(--neutral-100);
-  --sidebar-accent-foreground: var(--neutral-900);
-  --sidebar-border: var(--zinc-300);
-  --sidebar-ring: var(--primary-magenta-500);
-
-  /* Motion tokens */
-  --duration-fast: 100ms;
-  --duration-base: 200ms;
-  --duration-slow: 350ms;
-  --duration-loading: 1600ms;
-  --ease-standard: cubic-bezier(0.4, 0, 0.2, 1);
-  --ease-emphasized: cubic-bezier(0.2, 0, 0, 1);
+  --sidebar: oklch(97.91% 0 0); /* zinc-50 */
+  --sidebar-foreground: oklch(26.94% 0.0037 286.15); /* zinc-950 */
+  --sidebar-primary: oklch(55.06% 0.1886 311.45); /* primary-magenta-600 */
+  --sidebar-primary-foreground: oklch(100% 0 0); /* white */
+  --sidebar-accent: oklch(95.04% 0.0042 236.50); /* neutral-100 */
+  --sidebar-accent-foreground: oklch(32.95% 0.0209 254.12); /* neutral-900 */
+  --sidebar-border: oklch(78.06% 0.0056 286.27); /* zinc-300 */
+  --sidebar-ring: oklch(61.98% 0.2159 311.67); /* primary-magenta-500 */
 }
 
 /* Semantic tokens — Dark (Figma "Dark" collection). */
 .dark {
-  --background: var(--zinc-950);
-  --foreground: var(--zinc-50);
+  --background: oklch(26.94% 0.0037 286.15); /* zinc-950 */
+  --foreground: oklch(97.91% 0 0); /* zinc-50 */
   --scrim: rgba(0, 0, 0, 0.6);
 
-  --canvas: var(--zinc-975);
-  --canvas-foreground: var(--zinc-50);
+  --canvas: oklch(21.86% 0.0039 286.08); /* zinc-975 */
+  --canvas-foreground: oklch(97.91% 0 0); /* zinc-50 */
 
-  --header: var(--zinc-950);
-  --header-foreground: var(--zinc-50);
+  --header: oklch(26.94% 0.0037 286.15); /* zinc-950 */
+  --header-foreground: oklch(97.91% 0 0); /* zinc-50 */
 
-  --card: var(--zinc-900);
-  --card-foreground: var(--zinc-50);
+  --card: oklch(33.01% 0.0052 286.11); /* zinc-900 */
+  --card-foreground: oklch(97.91% 0 0); /* zinc-50 */
 
-  --popover: var(--zinc-900);
-  --popover-foreground: var(--zinc-50);
+  --popover: oklch(33.01% 0.0052 286.11); /* zinc-900 */
+  --popover-foreground: oklch(97.91% 0 0); /* zinc-50 */
 
-  --primary: var(--primary-magenta-500);
-  --primary-foreground: var(--black);
-  --primary-hover: var(--primary-magenta-400);
+  --primary: oklch(61.98% 0.2159 311.67); /* primary-magenta-500 */
+  --primary-foreground: oklch(0% 0 0); /* black */
+  --primary-hover: oklch(69.98% 0.1926 311.48); /* primary-magenta-400 */
 
-  --secondary: var(--neutral-800);
-  --secondary-foreground: var(--neutral-100);
+  --secondary: oklch(40% 0.0269 250.57); /* neutral-800 */
+  --secondary-foreground: oklch(95.04% 0.0042 236.50); /* neutral-100 */
 
-  --muted: var(--zinc-800);
-  --muted-foreground: var(--zinc-400);
-  --muted-foreground-strong: var(--zinc-300);
+  --muted: oklch(39.94% 0.0066 286.10); /* zinc-800 */
+  --muted-foreground: oklch(69.88% 0.0130 286.06); /* zinc-400 */
+  --muted-foreground-strong: oklch(78.06% 0.0056 286.27); /* zinc-300 */
 
-  --accent: var(--neutral-800);
-  --accent-foreground: var(--neutral-100);
+  --accent: oklch(40% 0.0269 250.57); /* neutral-800 */
+  --accent-foreground: oklch(95.04% 0.0042 236.50); /* neutral-100 */
 
-  --info: var(--blue-900);
-  --info-foreground: var(--blue-400);
+  --info: oklch(33.01% 0.1387 264.40); /* blue-900 */
+  --info-foreground: oklch(69.95% 0.1433 264.44); /* blue-400 */
 
-  --destructive: var(--red-900);
-  --destructive-foreground: var(--red-300);
+  --destructive: oklch(33.1% 0.1332 27.42); /* red-900 */
+  --destructive-foreground: oklch(78.02% 0.1024 27.78); /* red-300 */
 
-  --warning: var(--yellow-900);
-  --warning-foreground: var(--yellow-200);
+  --warning: oklch(33.09% 0.0677 92.20); /* yellow-900 */
+  --warning-foreground: oklch(87.09% 0.1248 91.93); /* yellow-200 */
 
-  --success: var(--green-900);
-  --success-foreground: var(--green-200);
+  --success: oklch(32.88% 0.0887 149.73); /* green-900 */
+  --success-foreground: oklch(87.04% 0.0814 149.55); /* green-200 */
 
-  --border: var(--zinc-700);
-  --input: var(--zinc-600);
-  --border-strong: var(--zinc-500);
-  --ring: var(--primary-magenta-400);
+  --border: oklch(47.01% 0.0112 285.96); /* zinc-700 */
+  --input: oklch(54.86% 0.0154 285.88); /* zinc-600 */
+  --border-strong: oklch(61.96% 0.0134 286.00); /* zinc-500 */
+  --ring: oklch(69.98% 0.1926 311.48); /* primary-magenta-400 */
 
-  --chart-1: var(--primary-magenta-400);
-  --chart-2: var(--accent-teal-400);
-  --chart-3: var(--highlight-yellow-300);
-  --chart-4: var(--blue-400);
-  --chart-5: var(--green-400);
+  --chart-1: oklch(69.98% 0.1926 311.48); /* primary-magenta-400 */
+  --chart-2: oklch(69.9% 0.0995 187.56); /* accent-teal-400 */
+  --chart-3: oklch(77.95% 0.1259 85.96); /* highlight-yellow-300 */
+  --chart-4: oklch(69.95% 0.1433 264.44); /* blue-400 */
+  --chart-5: oklch(69.96% 0.1814 149.67); /* green-400 */
 
-  --sidebar: var(--zinc-950);
-  --sidebar-foreground: var(--zinc-50);
-  --sidebar-primary: var(--primary-magenta-500);
-  --sidebar-primary-foreground: var(--black);
-  --sidebar-accent: var(--neutral-800);
-  --sidebar-accent-foreground: var(--neutral-100);
-  --sidebar-border: var(--zinc-700);
-  --sidebar-ring: var(--primary-magenta-400);
-}
-
-@keyframes nebari-fade-in {
-  from {
-    opacity: 0;
-  }
-  to {
-    opacity: 1;
-  }
-}
-
-@keyframes nebari-fade-out {
-  from {
-    opacity: 1;
-  }
-  to {
-    opacity: 0;
-  }
-}
-
-@keyframes nebari-slide-up-fade {
-  from {
-    opacity: 0;
-    transform: translateY(6px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
-@keyframes nebari-slide-down-fade {
-  from {
-    opacity: 1;
-    transform: translateY(0);
-  }
-  to {
-    opacity: 0;
-    transform: translateY(6px);
-  }
-}
-
-@keyframes nebari-skeleton-pulse {
-  0%,
-  100% {
-    opacity: 1;
-  }
-  50% {
-    opacity: 0.5;
-  }
+  --sidebar: oklch(26.94% 0.0037 286.15); /* zinc-950 */
+  --sidebar-foreground: oklch(97.91% 0 0); /* zinc-50 */
+  --sidebar-primary: oklch(61.98% 0.2159 311.67); /* primary-magenta-500 */
+  --sidebar-primary-foreground: oklch(0% 0 0); /* black */
+  --sidebar-accent: oklch(40% 0.0269 250.57); /* neutral-800 */
+  --sidebar-accent-foreground: oklch(95.04% 0.0042 236.50); /* neutral-100 */
+  --sidebar-border: oklch(47.01% 0.0112 285.96); /* zinc-700 */
+  --sidebar-ring: oklch(69.98% 0.1926 311.48); /* primary-magenta-400 */
 }
 
 @theme inline {
@@ -427,16 +376,77 @@
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-ring: var(--sidebar-ring);
 
-  --radius-sm: calc(var(--radius) - 4px);
-  --radius-md: calc(var(--radius) - 2px);
+  --radius-sm: calc(var(--radius) * 0.6);
+  --radius-md: calc(var(--radius) * 0.8);
   --radius-lg: var(--radius);
-  --radius-xl: calc(var(--radius) + 4px);
+  --radius-xl: calc(var(--radius) * 1.4);
+  --radius-2xl: calc(var(--radius) * 1.8);
+  --radius-3xl: calc(var(--radius) * 2.2);
+  --radius-4xl: calc(var(--radius) * 2.6);
+
+  /* Motion tokens. Tailwind emits these into `:root` when referenced, so the
+   * `--animate-*` values below and `var(--duration-*)` in app CSS both resolve. */
+  --duration-fast: 100ms;
+  --duration-base: 200ms;
+  --duration-slow: 350ms;
+  --duration-loading: 1600ms;
+  --ease-standard: cubic-bezier(0.4, 0, 0.2, 1);
+  --ease-emphasized: cubic-bezier(0.2, 0, 0, 1);
 
   --animate-fade-in: nebari-fade-in var(--duration-base) var(--ease-standard) both;
   --animate-fade-out: nebari-fade-out var(--duration-base) var(--ease-standard) both;
   --animate-slide-up-fade: nebari-slide-up-fade var(--duration-base) var(--ease-emphasized) both;
   --animate-slide-down-fade: nebari-slide-down-fade var(--duration-base) var(--ease-emphasized) both;
   --animate-skeleton-pulse: nebari-skeleton-pulse var(--duration-loading) var(--ease-standard) infinite;
+
+  @keyframes nebari-fade-in {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+  }
+
+  @keyframes nebari-fade-out {
+    from {
+      opacity: 1;
+    }
+    to {
+      opacity: 0;
+    }
+  }
+
+  @keyframes nebari-slide-up-fade {
+    from {
+      opacity: 0;
+      transform: translateY(6px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+
+  @keyframes nebari-slide-down-fade {
+    from {
+      opacity: 1;
+      transform: translateY(0);
+    }
+    to {
+      opacity: 0;
+      transform: translateY(6px);
+    }
+  }
+
+  @keyframes nebari-skeleton-pulse {
+    0%, 100% {
+      opacity: 1;
+    }
+    50% {
+      opacity: 0.5;
+    }
+  }
 }
 
 @layer base {

--- a/registry/nebari/skills/nebari-ui/SKILL.md
+++ b/registry/nebari/skills/nebari-ui/SKILL.md
@@ -170,12 +170,40 @@ link.
 
 ## Theming
 
-Install the theme once; it writes the Nebari brand color tokens and radius into
-the app's global stylesheet as CSS variables for both light and dark modes:
+Install the theme once; it writes the Nebari brand color tokens, radius, fonts,
+and motion tokens into the app's global stylesheet as CSS variables for both
+light and dark modes:
 
 ```sh
 npx shadcn add @nebari/theme
 ```
+
+- **What it writes, and where.** One `:root` block (the semantic light tokens
+  plus the Figma primitive ramps), one `.dark` block, and one `@theme inline`
+  block holding the Tailwind mappings, radius steps, motion tokens, and the
+  `@keyframes`. That is exactly the shape of
+  [`registry/nebari/globals.css`](https://github.com/nebari-dev/nebari-design/blob/main/registry/nebari/globals.css)
+  in the registry repo — the canonical reference when diffing an app stylesheet.
+- **Re-applying is safe, but resets Nebari-owned values.** On a stylesheet
+  already in that shape, running `npx shadcn add @nebari/theme` again changes
+  only whitespace. Because it is a `registry:theme` item, the CLI *overwrites*
+  every existing `:root` / `.dark` / `@theme inline` value the theme owns
+  (`--primary`, `--radius`, `--font-sans`, …) — that is how token updates
+  reach apps. Installing a component (`npx shadcn add @nebari/button`) pulls the
+  theme in transitively but only *appends* tokens that are missing; it never
+  overwrites.
+- **Keep app-owned overrides in their own block.** Never edit a Nebari value in
+  place — the next theme apply clobbers it. Put overrides and derived tokens in
+  a separate `:root` / `.dark` block *after* the Nebari one (or in a separately
+  imported file). The CLI merges only into the first matching block, and the
+  later declaration wins in the cascade:
+
+  ```css
+  /* App overrides — keep below the Nebari theme blocks. */
+  :root {
+    --primary-hover: color-mix(in oklch, var(--primary), black 12%);
+  }
+  ```
 
 - Tokens are **semantic** (`--primary`, `--muted-foreground`, `--destructive`,
   `--info`, `--success`, `--warning`, `--border`, `--ring`, chart + sidebar
@@ -510,7 +538,7 @@ tokens. Use them to add consistent, accessible, on-brand animation at the
 | `--ease-emphasized` | `cubic-bezier(0.2, 0, 0, 1)` | Overlays sliding into view |
 
 And five ready-made Tailwind `animate-*` utilities (backed by `@keyframes`
-that the theme installs):
+that the theme installs inside `@theme inline`):
 
 | Utility | Effect |
 |---|---|

--- a/scripts/derive-theme-item.ts
+++ b/scripts/derive-theme-item.ts
@@ -1,0 +1,135 @@
+/**
+ * Derives the installable `theme` registry item from `registry/nebari/globals.css`.
+ *
+ * `globals.css` is the single source of truth for tokens. The shadcn CLI can only
+ * ship flat key/value maps (`cssVars`) plus generic CSS (`css`), and it decides
+ * where each lands: `cssVars.light` → the first `:root`, `cssVars.dark` → `.dark`,
+ * `cssVars.theme` → `@theme inline`, `css["@keyframes …"]` → inside
+ * `@theme inline`, and any other `css` selector is upserted in place. This module
+ * maps the stylesheet onto those buckets so the built item re-creates the same
+ * structure, and `tests/theme.test.ts` fails when `registry.json` drifts from it.
+ *
+ * Classification rules:
+ *   - A `:root` variable is *semantic* (→ `cssVars.light`) when `@theme inline`
+ *     exposes it as a Tailwind color (`--color-X: var(--X)`), or when it is
+ *     `--radius`. Everything else in `:root` is a *primitive* (→ `css[":root"]`),
+ *     which keeps primitives out of `@theme` — they must not become utilities.
+ *   - Every `.dark` variable → `cssVars.dark`.
+ *   - Every `@theme inline` variable that is not a `--color-*` mapping or a
+ *     `--radius-*` step → `cssVars.theme` (fonts, motion tokens, `--animate-*`).
+ *     The CLI derives the `--color-*` mappings and the radius steps itself.
+ *   - Every `@keyframes` inside `@theme inline` → `css["@keyframes <name>"]`.
+ */
+import postcss, { type AtRule, type Container, type Rule } from 'postcss';
+
+export type ThemeItemCss = {
+  css: Record<string, Record<string, string | Record<string, string>>>;
+  cssVars: {
+    theme: Record<string, string>;
+    light: Record<string, string>;
+    dark: Record<string, string>;
+  };
+};
+
+function declarations(container: Container): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const node of container.nodes ?? []) {
+    if (node.type === 'decl') {
+      out[node.prop] = node.value;
+    }
+  }
+  return out;
+}
+
+function stripDashes(vars: Record<string, string>): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(vars).map(([prop, value]) => [
+      prop.replace(/^--/, ''),
+      value,
+    ]),
+  );
+}
+
+function only<T>(nodes: T[], what: string): T {
+  if (nodes.length !== 1) {
+    throw new Error(
+      `globals.css must contain exactly one ${what} (found ${nodes.length}); the shadcn CLI merges into the first match and appends to it.`,
+    );
+  }
+  return nodes[0];
+}
+
+export function deriveThemeItem(globalsCss: string): ThemeItemCss {
+  const root = postcss.parse(globalsCss);
+  const nodes = root.nodes ?? [];
+
+  const rootRule = only(
+    nodes.filter((n): n is Rule => n.type === 'rule' && n.selector === ':root'),
+    '`:root` rule',
+  );
+  const darkRule = only(
+    nodes.filter((n): n is Rule => n.type === 'rule' && n.selector === '.dark'),
+    '`.dark` rule',
+  );
+  const themeNode = only(
+    nodes.filter(
+      (n): n is AtRule =>
+        n.type === 'atrule' && n.name === 'theme' && n.params === 'inline',
+    ),
+    '`@theme inline` block',
+  );
+  const strayKeyframes = nodes.filter(
+    (n): n is AtRule => n.type === 'atrule' && n.name === 'keyframes',
+  );
+  if (strayKeyframes.length > 0) {
+    throw new Error(
+      `globals.css has top-level @keyframes (${strayKeyframes
+        .map((k) => k.params)
+        .join(
+          ', ',
+        )}); the shadcn CLI writes keyframes inside \`@theme inline\`, so they must live there to be deduplicated.`,
+    );
+  }
+
+  const themeDecls = declarations(themeNode);
+  const semanticNames = new Set<string>(['radius']);
+  for (const [prop, value] of Object.entries(themeDecls)) {
+    const match = prop.match(/^--color-(.+)$/);
+    if (match && value === `var(--${match[1]})`) {
+      semanticNames.add(match[1]);
+    }
+  }
+
+  const light: Record<string, string> = {};
+  const primitives: Record<string, string> = {};
+  for (const [prop, value] of Object.entries(declarations(rootRule))) {
+    const name = prop.replace(/^--/, '');
+    if (semanticNames.has(name)) {
+      light[name] = value;
+    } else {
+      primitives[prop] = value;
+    }
+  }
+
+  const theme: Record<string, string> = {};
+  for (const [prop, value] of Object.entries(themeDecls)) {
+    if (/^--color-/.test(prop) || /^--radius-/.test(prop)) continue;
+    theme[prop.replace(/^--/, '')] = value;
+  }
+
+  const css: ThemeItemCss['css'] = { ':root': primitives };
+  for (const node of themeNode.nodes ?? []) {
+    if (node.type !== 'atrule' || node.name !== 'keyframes') continue;
+    const steps: Record<string, Record<string, string>> = {};
+    for (const step of node.nodes ?? []) {
+      if (step.type !== 'rule') continue;
+      steps[step.selector.replace(/\s*,\s*/g, ', ')] = declarations(step);
+    }
+    css[`@keyframes ${node.params}`] = steps;
+  }
+
+  return {
+    css,
+    cssVars: { theme, light, dark: stripDashes(declarations(darkRule)) },
+  };
+}

--- a/scripts/sync-theme.ts
+++ b/scripts/sync-theme.ts
@@ -1,0 +1,26 @@
+/**
+ * Regenerates the `theme` item's `css` and `cssVars` in `registry.json` from
+ * `registry/nebari/globals.css`. Run `bun run sync:theme` after editing tokens;
+ * `tests/theme.test.ts` fails when the two are out of sync.
+ */
+import { readFileSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { deriveThemeItem } from './derive-theme-item';
+
+const root = resolve(import.meta.dirname, '..');
+const registryPath = resolve(root, 'registry.json');
+const globals = readFileSync(
+  resolve(root, 'registry/nebari/globals.css'),
+  'utf8',
+);
+const registry = JSON.parse(readFileSync(registryPath, 'utf8'));
+
+const item = registry.items.find((i: { name: string }) => i.name === 'theme');
+if (!item) throw new Error('registry.json has no `theme` item');
+
+const derived = deriveThemeItem(globals);
+item.css = derived.css;
+item.cssVars = derived.cssVars;
+
+writeFileSync(registryPath, `${JSON.stringify(registry, null, 2)}\n`);
+console.log('registry.json: theme item synced from globals.css');

--- a/tests/theme.test.ts
+++ b/tests/theme.test.ts
@@ -1,0 +1,256 @@
+/**
+ * Guards the contract between `registry/nebari/globals.css` and the installable
+ * `theme` item, and proves that `npx shadcn add @nebari/theme` is idempotent
+ * against a stylesheet that already carries the theme (nebari-design#151).
+ *
+ * The CLI tests run the real `shadcn` binary (the pinned devDependency) against
+ * a throwaway consumer project, because the merge behaviour under test — where
+ * keyframes land, which `:root` gets appended to, which radius steps get added,
+ * when existing values are overwritten — lives in the CLI, not in this repo.
+ */
+import { execFileSync } from 'node:child_process';
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import postcss, { type ChildNode, type Container } from 'postcss';
+import { afterAll, describe, expect, it } from 'vitest';
+import { deriveThemeItem } from '../scripts/derive-theme-item';
+
+const repoRoot = resolve(__dirname, '..');
+const globalsCss = readFileSync(
+  resolve(repoRoot, 'registry/nebari/globals.css'),
+  'utf8',
+);
+const registry = JSON.parse(
+  readFileSync(resolve(repoRoot, 'registry.json'), 'utf8'),
+) as {
+  items: {
+    name: string;
+    type: string;
+    css?: unknown;
+    cssVars?: unknown;
+    [key: string]: unknown;
+  }[];
+};
+const themeItem = registry.items.find((item) => item.name === 'theme');
+if (!themeItem) throw new Error('registry.json has no `theme` item');
+
+// ---------------------------------------------------------------------------
+// Normalisation: compare stylesheets structurally, ignoring comments and
+// whitespace (the CLI re-indents what it rewrites) and declaration order.
+// ---------------------------------------------------------------------------
+
+type Shape =
+  | { kind: 'decl'; prop: string; value: string }
+  | { kind: 'rule'; selector: string; nodes: Shape[] }
+  | { kind: 'atrule'; name: string; params: string; nodes: Shape[] | null };
+
+function shapeOf(container: Container): Shape[] {
+  const shapes: Shape[] = [];
+  for (const node of container.nodes ?? []) {
+    const shape = shapeOfNode(node);
+    if (shape) shapes.push(shape);
+  }
+  return shapes.sort((a, b) =>
+    JSON.stringify(a).localeCompare(JSON.stringify(b)),
+  );
+}
+
+function shapeOfNode(node: ChildNode): Shape | null {
+  const squash = (s: string) => s.replace(/\s+/g, ' ').trim();
+  switch (node.type) {
+    case 'decl':
+      return { kind: 'decl', prop: node.prop, value: squash(node.value) };
+    case 'rule':
+      return {
+        kind: 'rule',
+        selector: squash(node.selector),
+        nodes: shapeOf(node),
+      };
+    case 'atrule':
+      return {
+        kind: 'atrule',
+        name: node.name,
+        params: squash(node.params),
+        nodes: node.nodes ? shapeOf(node) : null,
+      };
+    default:
+      return null;
+  }
+}
+
+function normalise(css: string, omit: (shape: Shape) => boolean = () => false) {
+  return shapeOf(postcss.parse(css)).filter((shape) => !omit(shape));
+}
+
+// ---------------------------------------------------------------------------
+// A minimal Tailwind v4 consumer the CLI is happy to write into.
+// ---------------------------------------------------------------------------
+
+const shadcnBin = resolve(repoRoot, 'node_modules/.bin/shadcn');
+const tempDirs: string[] = [];
+
+function createConsumer(stylesheet: string) {
+  const dir = mkdtempSync(join(tmpdir(), 'nebari-theme-'));
+  tempDirs.push(dir);
+  mkdirSync(join(dir, 'src/lib'), { recursive: true });
+  writeFileSync(
+    join(dir, 'package.json'),
+    JSON.stringify({
+      name: 'consumer',
+      private: true,
+      type: 'module',
+      dependencies: {
+        react: '^19.1.0',
+        'react-dom': '^19.1.0',
+        tailwindcss: '^4.1.13',
+      },
+    }),
+  );
+  writeFileSync(
+    join(dir, 'tsconfig.json'),
+    JSON.stringify({
+      compilerOptions: {
+        jsx: 'react-jsx',
+        baseUrl: '.',
+        paths: { '@/*': ['./src/*'] },
+      },
+    }),
+  );
+  writeFileSync(
+    join(dir, 'components.json'),
+    JSON.stringify({
+      $schema: 'https://ui.shadcn.com/schema.json',
+      style: 'base-vega',
+      rsc: false,
+      tsx: true,
+      tailwind: {
+        config: '',
+        css: 'src/index.css',
+        baseColor: 'neutral',
+        cssVariables: true,
+        prefix: '',
+      },
+      iconLibrary: 'lucide',
+      aliases: {
+        components: '@/components',
+        ui: '@/components/ui',
+        lib: '@/lib',
+        utils: '@/lib/utils',
+        hooks: '@/hooks',
+      },
+    }),
+  );
+  writeFileSync(join(dir, 'src/lib/utils.ts'), 'export {};\n');
+  writeFileSync(join(dir, 'src/index.css'), stylesheet);
+  // The built item is the registry entry plus the item schema (it has no files).
+  writeFileSync(
+    join(dir, 'theme.json'),
+    JSON.stringify({
+      $schema: 'https://ui.shadcn.com/schema/registry-item.json',
+      ...themeItem,
+    }),
+  );
+  return {
+    dir,
+    applyTheme() {
+      execFileSync(
+        shadcnBin,
+        ['add', '--yes', '--overwrite', join(dir, 'theme.json')],
+        {
+          cwd: dir,
+          stdio: 'pipe',
+        },
+      );
+      return readFileSync(join(dir, 'src/index.css'), 'utf8');
+    },
+  };
+}
+
+afterAll(() => {
+  for (const dir of tempDirs) rmSync(dir, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+
+describe('theme item ↔ globals.css contract', () => {
+  it('registry.json `theme` is exactly what globals.css derives to (run `bun run sync:theme`)', () => {
+    const derived = deriveThemeItem(globalsCss);
+    expect(themeItem.css).toEqual(derived.css);
+    expect(themeItem.cssVars).toEqual(derived.cssVars);
+  });
+
+  it('ships every semantic token for both light and dark', () => {
+    const { light, dark } = deriveThemeItem(globalsCss).cssVars;
+    const lightOnly = Object.keys(light).filter((k) => !(k in dark));
+    expect(lightOnly).toEqual(['radius']);
+    expect(Object.keys(dark).filter((k) => !(k in light))).toEqual([]);
+  });
+
+  it('keeps primitives out of cssVars so the CLI never exposes them as Tailwind colors', () => {
+    const { css, cssVars } = deriveThemeItem(globalsCss);
+    const primitives = Object.keys(css[':root']);
+    expect(primitives).toContain('--primary-magenta-500');
+    expect(primitives).toContain('--zinc-950');
+    for (const prop of primitives) {
+      expect(cssVars.light).not.toHaveProperty(prop.replace(/^--/, ''));
+    }
+  });
+});
+
+describe('shadcn add @nebari/theme', () => {
+  const cliTimeout = 120_000;
+
+  it(
+    'is a no-op on a stylesheet that already carries the theme',
+    () => {
+      const consumer = createConsumer(globalsCss);
+      const applied = consumer.applyTheme();
+      expect(normalise(applied)).toEqual(normalise(globalsCss));
+    },
+    cliTimeout,
+  );
+
+  it(
+    'reaches a fixed point: applying twice produces the same bytes as applying once',
+    () => {
+      const consumer = createConsumer(globalsCss);
+      const once = consumer.applyTheme();
+      const twice = consumer.applyTheme();
+      expect(twice).toBe(once);
+    },
+    cliTimeout,
+  );
+
+  it(
+    'produces the globals.css structure on a fresh Tailwind stylesheet',
+    () => {
+      const consumer = createConsumer('@import "tailwindcss";\n');
+      const applied = consumer.applyTheme();
+      // `@layer base` is shadcn's project scaffold, not part of the theme item.
+      const isBaseLayer = (shape: Shape) =>
+        shape.kind === 'atrule' &&
+        shape.name === 'layer' &&
+        shape.params === 'base';
+      expect(normalise(applied)).toEqual(normalise(globalsCss, isBaseLayer));
+
+      const root = postcss.parse(applied);
+      const keyframes = root.nodes.filter(
+        (n) => n.type === 'atrule' && n.name === 'keyframes',
+      );
+      expect(keyframes, 'keyframes belong inside @theme inline').toHaveLength(
+        0,
+      );
+      expect(
+        root.nodes.filter((n) => n.type === 'rule' && n.selector === ':root'),
+      ).toHaveLength(1);
+    },
+    cliTimeout,
+  );
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,7 @@
     "registry",
     "stories",
     "tests",
+    "scripts",
     ".storybook",
     "vite.config.ts",
     "vitest.config.ts",


### PR DESCRIPTION
Fixes #151

## Problem

Re-applying the `theme` item — directly, or transitively through any `registry:ui` component — corrupted consumer stylesheets: the five `@keyframes` were duplicated inside `@theme inline`, light tokens were appended to the primitives `:root`, stray `--radius-2xl/3xl/4xl` steps appeared, and `var()` references were rewritten to literals. Five of six consumers in the #143 sweep had to be hand-merged.

Tracing the shadcn CLI (`update-css.ts`, `update-css-vars.ts`, `add-components.ts`) showed every symptom comes from one cause: `globals.css` did not match the shape the CLI writes, so its dedup and in-place merge never matched. The CLI deliberately places keyframes inside `@theme inline` and dedupes only there; it merges into the *first* `:root`; it always adds seven radius steps; and for `registry:theme` items it overwrites existing values.

## Changes

- **`globals.css` is now the CLI's canonical output.** One `:root` (primitive ramps + semantic light tokens), one `.dark`, one `@theme inline` that also holds fonts, radius steps, motion tokens and `@keyframes`. Semantic values are literal oklch with the primitive named in a trailing comment — the CLI can only ship literals and rewrites references on every apply. Radius steps use the CLI's multiplicative formulas (identical values at the default radius).
- **The `theme` item is derived from `globals.css`.** `scripts/derive-theme-item.ts` classifies each variable into the CLI's buckets; `bun run sync:theme` regenerates the item in `registry.json`. Token values are unchanged. The item now also ships the primitive ramps (via `css[":root"]`, so they never become Tailwind utilities) and the `--font-sans` / `--font-mono` tokens, so a fresh install matches `globals.css`.
- **`tests/theme.test.ts`** asserts `registry.json` equals the derivation, then runs the real pinned `shadcn` binary against a throwaway consumer to prove: applying the theme to `globals.css` is a structural no-op; a second apply is a byte-for-byte fixed point; a fresh Tailwind stylesheet gets the `globals.css` structure (keyframes inside `@theme inline`, a single `:root`).
- **Docs.** The `nebari-ui` skill's Theming section now explains what the theme writes, that explicit re-applies reset Nebari-owned values while component installs only append, and the pattern of keeping app-owned overrides (e.g. `--primary-hover: color-mix(...)`) in their own block *after* the Nebari one. AGENTS.md and the README describe the source-of-truth workflow.

## Verification

- Re-ran the issue's repro with `shadcn@4.21.0` against the new `globals.css`: ignoring whitespace, the only diff is five removed blank lines. With whitespace, the CLI re-indents primitives and keyframe steps to four spaces — hard-coded in the shadcn updater, cosmetic, and removed by any formatter.
- Biome, `tsc`, 731 unit/SSR tests and 180 Storybook browser tests pass; `build:registry` succeeds.

## Follow-up

After this lands, re-run the sweep on a real consumer (e.g. nebari-landing) to confirm a clean apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X7pio1M3PmRwFuX5F85ngG
