### PR TITLE
Import registry siblings as `@/components/ui/<name>` so installed files match the source

### DIFF
--- a/.claude/skills/nebari-component/SKILL.md
+++ b/.claude/skills/nebari-component/SKILL.md
@@ -23,8 +23,12 @@ entry, a Storybook story, and a Vitest test — then a verification gate.
 Conventions that are easy to get wrong, encoded once here:
 
 - Components live in `registry/nebari/ui/<name>.tsx` (kebab-case file name).
-- The `@/*` path alias resolves to `registry/nebari/*`; `@/ui` → `registry/nebari/ui`,
-  `@/lib` → `registry/nebari/lib`.
+- The `@/*` path alias resolves to `registry/nebari/*`; the more specific
+  `@/components/ui` → `registry/nebari/ui`, `@/lib` → `registry/nebari/lib`,
+  `@/hooks` → `registry/nebari/hooks`.
+- Import registry siblings as `@/components/ui/<name>`, never `@/ui/<name>` (Biome
+  rejects it). It is the path the shadcn CLI emits for a consumer's default
+  aliases, so installed files stay byte-identical to the registry source.
 - Composition uses **Base UI's `render` prop** (`@base-ui/react`), not
   Radix `asChild`.
 - Stories live in top-level `stories/<name>.stories.tsx`, tests in top-level
@@ -407,7 +411,7 @@ applied by every story under `Components/*`
 
 ```tsx
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { Button } from '@/ui/button';
+import { Button } from '@/components/ui/button';
 
 const meta = {
   title: 'Components/Button',
@@ -569,7 +573,7 @@ and `render`-prop composition:
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
-import { Button } from '@/ui/button';
+import { Button } from '@/components/ui/button';
 
 describe('Button', () => {
   it('renders its children', () => {

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -16,6 +16,10 @@ const config: StorybookConfig = {
       ...viteConfig.resolve,
       alias: {
         ...viteConfig.resolve?.alias,
+        '@/components/ui': resolve(
+          import.meta.dirname,
+          '../registry/nebari/ui',
+        ),
         '@': resolve(import.meta.dirname, '../registry/nebari'),
       },
     };

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,9 +68,18 @@ logo-mark/ symbol/      # brand assets — do not modify
 
 ### Path alias
 
-`@/*` resolves to `registry/nebari/*` (see `tsconfig.json` and `vitest.config.ts`).
-So `@/ui/button` → `registry/nebari/ui/button.tsx`, `@/lib/utils` →
-`registry/nebari/lib/utils.ts`. There is no `src/`.
+`@/*` resolves to `registry/nebari/*`, and the more specific `@/components/ui/*`
+resolves to `registry/nebari/ui/*` (see `tsconfig.json`, `vite.config.ts`,
+`vitest.config.ts`, and `.storybook/main.ts`). So `@/components/ui/button` →
+`registry/nebari/ui/button.tsx`, `@/lib/utils` → `registry/nebari/lib/utils.ts`,
+`@/hooks/use-theme-preference` → `registry/nebari/hooks/use-theme-preference.ts`.
+There is no `src/`.
+
+Always import registry siblings as `@/components/ui/<name>` — never `@/ui/<name>`
+(Biome's `noRestrictedImports` rejects it). That is the path the shadcn CLI emits
+for a consumer with the default `components.json` aliases, so an installed file is
+byte-identical to its `registry/nebari/ui/<name>.tsx` source and drift checks can
+use a plain `diff`.
 
 ## Authoring a component
 

--- a/README.md
+++ b/README.md
@@ -149,7 +149,8 @@ the house recipe.
 
 This project uses [Bun](https://bun.sh/), [TypeScript](https://www.typescriptlang.org/),
 and [Tailwind CSS v4](https://tailwindcss.com/). The `@/*` path alias resolves to
-`registry/nebari`.
+`registry/nebari`, and `@/components/ui/*` resolves to `registry/nebari/ui/*` so
+registry sources import siblings exactly as the shadcn CLI emits them.
 
 ```sh
 bun install              # install dependencies
@@ -168,8 +169,9 @@ bun run storybook
 
 The dev server runs at <http://localhost:6006>. Stories live in the top-level
 `stories/` directory, including MDX docs pages and component stories named
-`*.stories.tsx`. Storybook uses the same Tailwind v4 setup and `@/*` alias as the
-registry source, so imports resolve the same way they do in tests and builds.
+`*.stories.tsx`. Storybook uses the same Tailwind v4 setup and `@/*` /
+`@/components/ui/*` aliases as the registry source, so imports resolve the same
+way they do in tests and builds.
 
 Component stories follow a shared controls pattern. `Default` is the interactive
 playground and exposes the documented knobs; every other story narrows controls
@@ -210,8 +212,8 @@ served from the same Pages build under `/r/`.
 Components are tested with [Vitest](https://vitest.dev/),
 [Testing Library](https://testing-library.com/docs/react-testing-library/intro/),
 and `jsdom`. Vitest reuses the same `@vitejs/plugin-react`, Tailwind, and `@` →
-`registry/nebari` alias setup as the registry and Storybook, so tests resolve
-imports exactly like the app does.
+`registry/nebari` / `@/components/ui` → `registry/nebari/ui` alias setup as the
+registry and Storybook, so tests resolve imports exactly like the app does.
 
 ```sh
 bun run test            # run the suite once

--- a/biome.json
+++ b/biome.json
@@ -1,6 +1,10 @@
 {
   "$schema": "https://biomejs.dev/schemas/2.5.6/schema.json",
-  "vcs": { "enabled": true, "clientKind": "git", "useIgnoreFile": true },
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
   "files": {
     "includes": [
       "**",
@@ -33,9 +37,31 @@
       "arrowParentheses": "always"
     }
   },
-  "linter": { "enabled": true, "rules": { "preset": "recommended" } },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "preset": "recommended",
+      "style": {
+        "noRestrictedImports": {
+          "level": "error",
+          "options": {
+            "patterns": [
+              {
+                "group": ["@/ui", "@/ui/**"],
+                "message": "Import registry siblings as `@/components/ui/<name>` — the path the shadcn CLI emits for a consumer with default aliases — so installed files stay byte-identical to the registry source."
+              }
+            ]
+          }
+        }
+      }
+    }
+  },
   "assist": {
     "enabled": true,
-    "actions": { "source": { "organizeImports": "on" } }
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
+    }
   }
 }

--- a/components.json
+++ b/components.json
@@ -13,7 +13,7 @@
   "iconLibrary": "lucide",
   "aliases": {
     "components": "@/components",
-    "ui": "@/ui",
+    "ui": "@/components/ui",
     "lib": "@/lib",
     "utils": "@/lib/utils",
     "hooks": "@/hooks"

--- a/registry/nebari/skills/nebari-ui/SKILL.md
+++ b/registry/nebari/skills/nebari-ui/SKILL.md
@@ -63,10 +63,10 @@ npx shadcn add @nebari/theme
 npx shadcn add @nebari/button
 ```
 
-Installed files land under the app's configured aliases (`@/ui`, `@/hooks`,
-`@/lib`), so
-imports look like `import { Button } from '@/components/ui/button'` — match the
-host app's existing alias resolution.
+Installed files land under the app's configured aliases (`@/components/ui`,
+`@/hooks`, `@/lib` by default), so imports look like
+`import { Button } from '@/components/ui/button'` — match the host app's existing
+alias resolution.
 
 ## Treat installed components as managed
 

--- a/registry/nebari/ui/button.tsx
+++ b/registry/nebari/ui/button.tsx
@@ -1,8 +1,8 @@
 import { useRender } from '@base-ui/react/use-render';
 import { cva, type VariantProps } from 'class-variance-authority';
 import { Children, isValidElement, type ReactNode } from 'react';
+import { Spinner } from '@/components/ui/spinner';
 import { cn } from '@/lib/utils';
-import { Spinner } from '@/ui/spinner';
 
 const buttonVariants = cva(
   "inline-flex shrink-0 items-center justify-center gap-2 whitespace-nowrap rounded-md font-medium underline-offset-4 outline-none motion-safe:transition-[color,background-color,border-color,opacity,transform] motion-safe:duration-(--duration-fast) motion-safe:ease-(--ease-standard) motion-safe:active:scale-[0.97] hover:underline focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background data-[disabled]:pointer-events-none data-[disabled]:text-muted-foreground data-[disabled]:no-underline data-[disabled]:shadow-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",

--- a/registry/nebari/ui/calendar.tsx
+++ b/registry/nebari/ui/calendar.tsx
@@ -10,6 +10,7 @@ import {
   useRef,
   useState,
 } from 'react';
+import { Button } from '@/components/ui/button';
 import {
   addDays,
   addMonths,
@@ -22,7 +23,6 @@ import {
   startOfMonth,
 } from '@/lib/date';
 import { cn } from '@/lib/utils';
-import { Button } from '@/ui/button';
 
 const weekdays = ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'] as const;
 

--- a/registry/nebari/ui/combobox.tsx
+++ b/registry/nebari/ui/combobox.tsx
@@ -1,8 +1,8 @@
 import { Combobox as ComboboxPrimitive } from '@base-ui/react/combobox';
 import { CheckIcon, ChevronsUpDownIcon, XIcon } from 'lucide-react';
 import { type ComponentProps, createContext, useContext } from 'react';
+import { badgeVariants } from '@/components/ui/badge';
 import { cn } from '@/lib/utils';
-import { badgeVariants } from '@/ui/badge';
 
 type ComboboxContentProps = ComboboxPrimitive.Popup.Props &
   Pick<

--- a/registry/nebari/ui/data-table.tsx
+++ b/registry/nebari/ui/data-table.tsx
@@ -33,9 +33,8 @@ import {
   XIcon,
 } from 'lucide-react';
 import { type ReactNode, useEffect, useMemo, useRef } from 'react';
-import { cn } from '@/lib/utils';
-import { Button } from '@/ui/button';
-import { Checkbox } from '@/ui/checkbox';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
 import {
   DropdownMenu,
   DropdownMenuCheckboxItem,
@@ -44,15 +43,15 @@ import {
   DropdownMenuGroupLabel,
   DropdownMenuPortal,
   DropdownMenuTrigger,
-} from '@/ui/dropdown-menu';
-import { Input } from '@/ui/input';
+} from '@/components/ui/dropdown-menu';
+import { Input } from '@/components/ui/input';
 import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from '@/ui/select';
+} from '@/components/ui/select';
 import {
   Table,
   TableBody,
@@ -60,7 +59,8 @@ import {
   TableHead,
   TableHeader,
   TableRow,
-} from '@/ui/table';
+} from '@/components/ui/table';
+import { cn } from '@/lib/utils';
 
 /**
  * The TanStack feature set every {@link DataTable} is built from. Exported so

--- a/registry/nebari/ui/date-picker.tsx
+++ b/registry/nebari/ui/date-picker.tsx
@@ -16,6 +16,17 @@ import {
   useState,
 } from 'react';
 import {
+  Calendar,
+  type CalendarDateRange,
+  type CalendarRangeSelectDetails,
+} from '@/components/ui/calendar';
+import {
+  Field,
+  FieldDescription,
+  FieldError,
+  FieldLabel,
+} from '@/components/ui/field';
+import {
   addDays,
   addMonths,
   formatDate,
@@ -24,12 +35,6 @@ import {
   startOfDay,
 } from '@/lib/date';
 import { cn } from '@/lib/utils';
-import {
-  Calendar,
-  type CalendarDateRange,
-  type CalendarRangeSelectDetails,
-} from '@/ui/calendar';
-import { Field, FieldDescription, FieldError, FieldLabel } from '@/ui/field';
 
 const datePickerVariants = cva('flex w-72 flex-col gap-1.5', {
   variants: {

--- a/registry/nebari/ui/dialog.tsx
+++ b/registry/nebari/ui/dialog.tsx
@@ -1,8 +1,8 @@
 import { Dialog as DialogPrimitive } from '@base-ui/react/dialog';
 import { XIcon } from 'lucide-react';
 import type * as React from 'react';
+import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
-import { Button } from '@/ui/button';
 
 type DialogProps = DialogPrimitive.Root.Props;
 

--- a/registry/nebari/ui/drawer.tsx
+++ b/registry/nebari/ui/drawer.tsx
@@ -2,8 +2,8 @@ import { Drawer as DrawerPrimitive } from '@base-ui/react/drawer';
 import { XIcon } from 'lucide-react';
 import type * as React from 'react';
 import { createContext, useContext, useMemo, useRef } from 'react';
+import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
-import { Button } from '@/ui/button';
 
 type DrawerSwipeDirection = NonNullable<
   DrawerPrimitive.Root.Props['swipeDirection']

--- a/registry/nebari/ui/dropdown-menu.tsx
+++ b/registry/nebari/ui/dropdown-menu.tsx
@@ -2,8 +2,8 @@ import { Menu as MenuPrimitive } from '@base-ui/react/menu';
 import { cva, type VariantProps } from 'class-variance-authority';
 import { CheckIcon, ChevronRightIcon, ChevronsUpDownIcon } from 'lucide-react';
 import type * as React from 'react';
+import { Button, type ButtonProps } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
-import { Button, type ButtonProps } from '@/ui/button';
 
 const dropdownMenuItemVariants = cva(
   'relative flex w-full cursor-default items-center gap-2 rounded-[calc(var(--radius-md)-var(--spacing))] px-1.5 py-1 text-sm outline-hidden select-none data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring motion-safe:transition-[color,background-color] motion-safe:duration-(--duration-fast) motion-safe:ease-(--ease-standard)',

--- a/registry/nebari/ui/navigation-menu.tsx
+++ b/registry/nebari/ui/navigation-menu.tsx
@@ -1,7 +1,6 @@
 import { useRender } from '@base-ui/react/use-render';
 import { cva } from 'class-variance-authority';
 import type { ComponentProps, MouseEvent, ReactNode } from 'react';
-import { cn } from '@/lib/utils';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -10,7 +9,8 @@ import {
   type DropdownMenuProps,
   DropdownMenuTrigger,
   type DropdownMenuTriggerProps,
-} from '@/ui/dropdown-menu';
+} from '@/components/ui/dropdown-menu';
+import { cn } from '@/lib/utils';
 
 type NavLinkProps = useRender.ComponentProps<'a'> & {
   /** Marks the link as the current page or section. */

--- a/registry/nebari/ui/sidebar.tsx
+++ b/registry/nebari/ui/sidebar.tsx
@@ -11,13 +11,13 @@ import {
   useMemo,
   useState,
 } from 'react';
-import { cn } from '@/lib/utils';
 import {
   Tooltip,
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
-} from '@/ui/tooltip';
+} from '@/components/ui/tooltip';
+import { cn } from '@/lib/utils';
 
 type SidebarState = 'expanded' | 'collapsed';
 

--- a/registry/nebari/ui/toast.tsx
+++ b/registry/nebari/ui/toast.tsx
@@ -15,8 +15,8 @@ import {
   X,
 } from 'lucide-react';
 import { type ReactNode, useMemo } from 'react';
+import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
-import { Button } from '@/ui/button';
 
 /** Semantic color treatment for each toast status icon. */
 const toastIconVariants = cva(

--- a/stories/accordion.stories.tsx
+++ b/stories/accordion.stories.tsx
@@ -8,7 +8,7 @@ import {
   type AccordionHeadingLevel,
   AccordionItem,
   AccordionTrigger,
-} from '@/ui/accordion';
+} from '@/components/ui/accordion';
 
 /** Maps readable control labels to the item values expanded on first render. */
 const OPEN_ITEMS_BY_KEY = {

--- a/stories/alert.stories.tsx
+++ b/stories/alert.stories.tsx
@@ -7,8 +7,8 @@ import {
   AlertDescription,
   type AlertProps,
   AlertTitle,
-} from '@/ui/alert';
-import { Button } from '@/ui/button';
+} from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
 
 type AlertStoryArgs = Omit<AlertProps, 'role'> & {
   role: 'auto' | 'status' | 'alert';

--- a/stories/badge.stories.tsx
+++ b/stories/badge.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Bell, Check, Circle, TrendingUp } from 'lucide-react';
-import { Badge } from '@/ui/badge';
+import { Badge } from '@/components/ui/badge';
 
 const meta = {
   title: 'Components/Badge',

--- a/stories/breadcrumb.stories.tsx
+++ b/stories/breadcrumb.stories.tsx
@@ -20,7 +20,7 @@ import {
   BreadcrumbList,
   BreadcrumbPage,
   BreadcrumbSeparator,
-} from '@/ui/breadcrumb';
+} from '@/components/ui/breadcrumb';
 
 type BreadcrumbCollapsedVariant = 'ellipsis' | 'dropdown';
 type BreadcrumbPreviewVariant = 'default' | BreadcrumbCollapsedVariant;

--- a/stories/button-group.stories.tsx
+++ b/stories/button-group.stories.tsx
@@ -12,19 +12,19 @@ import {
 } from 'lucide-react';
 import type { ReactNode } from 'react';
 import { expect, userEvent, waitFor, within } from 'storybook/test';
-import { Button } from '@/ui/button';
+import { Button } from '@/components/ui/button';
 import {
   ButtonGroup,
   ButtonGroupSeparator,
   ButtonGroupText,
-} from '@/ui/button-group';
+} from '@/components/ui/button-group';
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuPortal,
   DropdownMenuTrigger,
-} from '@/ui/dropdown-menu';
+} from '@/components/ui/dropdown-menu';
 
 type SplitButtonProps = {
   groupLabel: string;

--- a/stories/button.stories.tsx
+++ b/stories/button.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { ArrowRight, Plus, Trash2 } from 'lucide-react';
-import { Button } from '@/ui/button';
+import { Button } from '@/components/ui/button';
 
 const meta = {
   title: 'Components/Button',

--- a/stories/calendar.stories.tsx
+++ b/stories/calendar.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { expect, within } from 'storybook/test';
+import { Calendar, Day } from '@/components/ui/calendar';
 import { addDays, formatDate, startOfMonth } from '@/lib/date';
-import { Calendar, Day } from '@/ui/calendar';
 
 const storyToday = new Date();
 const storyMonth = startOfMonth(storyToday);

--- a/stories/card.stories.tsx
+++ b/stories/card.stories.tsx
@@ -1,8 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { ArrowRight, CalendarDays } from 'lucide-react';
 import type * as React from 'react';
-import { Badge } from '@/ui/badge';
-import { Button } from '@/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
 import {
   Card,
   CardAction,
@@ -11,9 +11,9 @@ import {
   CardFooter,
   CardHeader,
   CardTitle,
-} from '@/ui/card';
-import { Field, FieldLabel } from '@/ui/field';
-import { Input } from '@/ui/input';
+} from '@/components/ui/card';
+import { Field, FieldLabel } from '@/components/ui/field';
+import { Input } from '@/components/ui/input';
 
 type CardStoryArgs = React.ComponentProps<typeof Card> & {
   showFooter?: boolean;

--- a/stories/checkbox.stories.tsx
+++ b/stories/checkbox.stories.tsx
@@ -1,8 +1,13 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import type { ComponentProps } from 'react';
 import { useState } from 'react';
-import { Checkbox, CheckboxGroup } from '@/ui/checkbox';
-import { Field, FieldDescription, FieldError, FieldLabel } from '@/ui/field';
+import { Checkbox, CheckboxGroup } from '@/components/ui/checkbox';
+import {
+  Field,
+  FieldDescription,
+  FieldError,
+  FieldLabel,
+} from '@/components/ui/field';
 
 type CheckboxVariant = NonNullable<ComponentProps<typeof Checkbox>['variant']>;
 

--- a/stories/code-block.stories.tsx
+++ b/stories/code-block.stories.tsx
@@ -4,11 +4,11 @@ import {
   CodeBlockBody,
   CodeBlockCopyButton,
   CodeBlockHeader,
-} from '@/ui/code-block';
+} from '@/components/ui/code-block';
 
 const basicSnippet = `pnpm dlx shadcn@latest add @nebari/code-block`;
 
-const multiLineSnippet = `import { CodeBlock, CodeBlockBody } from '@/ui/code-block';
+const multiLineSnippet = `import { CodeBlock, CodeBlockBody } from '@/components/ui/code-block';
 
 export function Example() {
   return (

--- a/stories/combobox.stories.tsx
+++ b/stories/combobox.stories.tsx
@@ -15,8 +15,13 @@ import {
   ComboboxList,
   ComboboxSeparator,
   ComboboxValue,
-} from '@/ui/combobox';
-import { Field, FieldDescription, FieldError, FieldLabel } from '@/ui/field';
+} from '@/components/ui/combobox';
+import {
+  Field,
+  FieldDescription,
+  FieldError,
+  FieldLabel,
+} from '@/components/ui/field';
 
 interface Framework {
   label: string;

--- a/stories/data-table.stories.tsx
+++ b/stories/data-table.stories.tsx
@@ -6,9 +6,9 @@ import {
   PlusIcon,
   Trash2Icon,
 } from 'lucide-react';
-import { Badge } from '@/ui/badge';
-import { Button } from '@/ui/button';
-import { DataTable, type DataTableColumnDef } from '@/ui/data-table';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { DataTable, type DataTableColumnDef } from '@/components/ui/data-table';
 
 type Workspace = {
   id: string;

--- a/stories/date-picker.stories.tsx
+++ b/stories/date-picker.stories.tsx
@@ -1,12 +1,12 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { expect, userEvent, waitFor, within } from 'storybook/test';
+import { DatePicker } from '@/components/ui/date-picker';
 import {
   addDays,
   formatDate,
   formatSegmentDate,
   startOfMonth,
 } from '@/lib/date';
-import { DatePicker } from '@/ui/date-picker';
 
 const storyToday = new Date();
 const storyMonth = startOfMonth(storyToday);

--- a/stories/dialog.stories.tsx
+++ b/stories/dialog.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import type { ComponentProps, ReactNode } from 'react';
 import { useState } from 'react';
 import { expect, userEvent, waitFor, within } from 'storybook/test';
-import { Button } from '@/ui/button';
+import { Button } from '@/components/ui/button';
 import {
   Dialog,
   DialogClose,
@@ -13,7 +13,7 @@ import {
   DialogHeader,
   DialogTitle,
   DialogTrigger,
-} from '@/ui/dialog';
+} from '@/components/ui/dialog';
 
 // Storybook args serialize as strings, so `boolean | 'trap-focus'` is keyed by string.
 const MODAL_BY_KEY = {

--- a/stories/drawer.stories.tsx
+++ b/stories/drawer.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { expect, userEvent, waitFor, within } from 'storybook/test';
-import { Button } from '@/ui/button';
+import { Button } from '@/components/ui/button';
 import {
   Drawer,
   DrawerBody,
@@ -12,7 +12,7 @@ import {
   type DrawerSide,
   DrawerTitle,
   DrawerTrigger,
-} from '@/ui/drawer';
+} from '@/components/ui/drawer';
 
 // `auto` keeps the per-side default (shown for bottom) reachable from the knob.
 const SWIPE_HANDLE_BY_KEY = {

--- a/stories/dropdown-menu.stories.tsx
+++ b/stories/dropdown-menu.stories.tsx
@@ -11,7 +11,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuSubmenu,
   DropdownMenuTrigger,
-} from '@/ui/dropdown-menu';
+} from '@/components/ui/dropdown-menu';
 
 const meta = {
   title: 'Components/Dropdown Menu',

--- a/stories/field.stories.tsx
+++ b/stories/field.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { Field, FieldDescription, FieldLabel } from '@/ui/field';
-import { Switch } from '@/ui/switch';
+import { Field, FieldDescription, FieldLabel } from '@/components/ui/field';
+import { Switch } from '@/components/ui/switch';
 
 const meta = {
   title: 'Components/Field',

--- a/stories/input.stories.tsx
+++ b/stories/input.stories.tsx
@@ -1,6 +1,11 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { Field, FieldDescription, FieldError, FieldLabel } from '@/ui/field';
-import { Input } from '@/ui/input';
+import {
+  Field,
+  FieldDescription,
+  FieldError,
+  FieldLabel,
+} from '@/components/ui/field';
+import { Input } from '@/components/ui/input';
 
 const meta = {
   title: 'Components/Input',

--- a/stories/label.stories.tsx
+++ b/stories/label.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { Input } from '@/ui/input';
-import { Label } from '@/ui/label';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
 
 const meta = {
   title: 'Components/Label',

--- a/stories/navigation-menu.stories.tsx
+++ b/stories/navigation-menu.stories.tsx
@@ -1,14 +1,14 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Bell, Home, Settings, User } from 'lucide-react';
 import { expect, userEvent, within } from 'storybook/test';
-import { DropdownMenuItem } from '@/ui/dropdown-menu';
+import { DropdownMenuItem } from '@/components/ui/dropdown-menu';
 import {
   MenuBar,
   MenuBarActions,
   MenuBarNav,
   NavDropdownMenu,
   NavLink,
-} from '@/ui/navigation-menu';
+} from '@/components/ui/navigation-menu';
 
 const meta = {
   title: 'Components/Navigation Menu',

--- a/stories/radio-group.stories.tsx
+++ b/stories/radio-group.stories.tsx
@@ -1,7 +1,12 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import type { ComponentProps } from 'react';
-import { Field, FieldDescription, FieldError, FieldLabel } from '@/ui/field';
-import { RadioGroup, RadioGroupItem } from '@/ui/radio-group';
+import {
+  Field,
+  FieldDescription,
+  FieldError,
+  FieldLabel,
+} from '@/components/ui/field';
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
 
 type RadioGroupStoryArgs = ComponentProps<typeof RadioGroupItem> &
   Pick<ComponentProps<typeof RadioGroup>, 'orientation'>;

--- a/stories/select.stories.tsx
+++ b/stories/select.stories.tsx
@@ -1,7 +1,12 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import type { ComponentProps, ReactNode } from 'react';
 import { expect, userEvent, waitFor, within } from 'storybook/test';
-import { Field, FieldDescription, FieldError, FieldLabel } from '@/ui/field';
+import {
+  Field,
+  FieldDescription,
+  FieldError,
+  FieldLabel,
+} from '@/components/ui/field';
 import {
   Select,
   SelectContent,
@@ -11,7 +16,7 @@ import {
   SelectSeparator,
   SelectTrigger,
   SelectValue,
-} from '@/ui/select';
+} from '@/components/ui/select';
 
 interface SelectOption {
   label: string;

--- a/stories/sidebar.stories.tsx
+++ b/stories/sidebar.stories.tsx
@@ -23,7 +23,7 @@ import {
   DropdownMenuPortal,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
-} from '@/ui/dropdown-menu';
+} from '@/components/ui/dropdown-menu';
 import {
   Sidebar,
   SidebarContent,
@@ -41,7 +41,7 @@ import {
   SidebarProvider,
   SidebarSeparator,
   SidebarTrigger,
-} from '@/ui/sidebar';
+} from '@/components/ui/sidebar';
 
 type SidebarMenuButtonVariant = NonNullable<
   ComponentProps<typeof SidebarMenuButton>['variant']

--- a/stories/skeleton.stories.tsx
+++ b/stories/skeleton.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { Skeleton } from '@/ui/skeleton';
+import { Skeleton } from '@/components/ui/skeleton';
 
 const meta = {
   title: 'Components/Skeleton',

--- a/stories/slider.stories.tsx
+++ b/stories/slider.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
-import { Field, FieldLabel } from '@/ui/field';
-import { Slider } from '@/ui/slider';
+import { Field, FieldLabel } from '@/components/ui/field';
+import { Slider } from '@/components/ui/slider';
 
 function ControlledSlider({
   disabled,

--- a/stories/spinner.stories.tsx
+++ b/stories/spinner.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { Spinner } from '@/ui/spinner';
+import { Spinner } from '@/components/ui/spinner';
 
 const meta = {
   title: 'Components/Spinner',

--- a/stories/switch.stories.tsx
+++ b/stories/switch.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { Field, FieldDescription, FieldLabel } from '@/ui/field';
-import { Switch } from '@/ui/switch';
+import { Field, FieldDescription, FieldLabel } from '@/components/ui/field';
+import { Switch } from '@/components/ui/switch';
 
 const meta = {
   title: 'Components/Switch',

--- a/stories/table.stories.tsx
+++ b/stories/table.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { CopyIcon, Trash2Icon } from 'lucide-react';
 import type { ReactNode } from 'react';
-import { Button } from '@/ui/button';
+import { Button } from '@/components/ui/button';
 import {
   Table,
   TableBody,
@@ -11,7 +11,7 @@ import {
   TableHead,
   TableHeader,
   TableRow,
-} from '@/ui/table';
+} from '@/components/ui/table';
 
 const environments = [
   {

--- a/stories/tabs.stories.tsx
+++ b/stories/tabs.stories.tsx
@@ -1,7 +1,13 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { BarChart3, Code2, Eye, Settings } from 'lucide-react';
 import type { ComponentProps } from 'react';
-import { Tabs, TabsIndicator, TabsList, TabsPanel, TabsTab } from '@/ui/tabs';
+import {
+  Tabs,
+  TabsIndicator,
+  TabsList,
+  TabsPanel,
+  TabsTab,
+} from '@/components/ui/tabs';
 
 type TabsVariant = NonNullable<ComponentProps<typeof TabsList>['variant']>;
 

--- a/stories/textarea.stories.tsx
+++ b/stories/textarea.stories.tsx
@@ -1,7 +1,12 @@
 import { Field as FieldPrimitive } from '@base-ui/react/field';
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { Field, FieldDescription, FieldError, FieldLabel } from '@/ui/field';
-import { Textarea } from '@/ui/textarea';
+import {
+  Field,
+  FieldDescription,
+  FieldError,
+  FieldLabel,
+} from '@/components/ui/field';
+import { Textarea } from '@/components/ui/textarea';
 
 const meta = {
   title: 'Components/Textarea',

--- a/stories/theme-provider.stories.tsx
+++ b/stories/theme-provider.stories.tsx
@@ -1,10 +1,10 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { type ReactNode, useEffect, useState } from 'react';
 import { expect, userEvent, within } from 'storybook/test';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
 import { ThemeProvider, useTheme } from '@/hooks/theme-provider';
 import { THEME_MODES, type ThemeMode } from '@/hooks/use-theme-preference';
-import { Alert, AlertDescription, AlertTitle } from '@/ui/alert';
-import { Button } from '@/ui/button';
 import {
   THEME_MODE_LABELS,
   useReturnThemeToToolbar,

--- a/stories/toast.stories.tsx
+++ b/stories/toast.stories.tsx
@@ -1,8 +1,13 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useEffect, useState } from 'react';
 import { expect, userEvent, waitFor, within } from 'storybook/test';
-import { Button } from '@/ui/button';
-import { Toaster, type ToasterProps, type ToastType, toast } from '@/ui/toast';
+import { Button } from '@/components/ui/button';
+import {
+  Toaster,
+  type ToasterProps,
+  type ToastType,
+  toast,
+} from '@/components/ui/toast';
 
 /**
  * `auto` leaves `priority` unset on the manager item so `Toaster` derives it

--- a/stories/tooltip.stories.tsx
+++ b/stories/tooltip.stories.tsx
@@ -1,12 +1,12 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { CircleHelpIcon, CopyIcon } from 'lucide-react';
-import { Button } from '@/ui/button';
+import { Button } from '@/components/ui/button';
 import {
   Tooltip,
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
-} from '@/ui/tooltip';
+} from '@/components/ui/tooltip';
 
 const meta = {
   title: 'Components/Tooltip',

--- a/stories/use-code-block-context.stories.tsx
+++ b/stories/use-code-block-context.stories.tsx
@@ -1,19 +1,19 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
 import { expect, userEvent, within } from 'storybook/test';
-import { Alert, AlertDescription, AlertTitle } from '@/ui/alert';
-import { Button } from '@/ui/button';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
 import {
   CodeBlock,
   CodeBlockBody,
   CodeBlockCopyButton,
   CodeBlockHeader,
   useCodeBlockContext,
-} from '@/ui/code-block';
+} from '@/components/ui/code-block';
 
 const SNIPPETS = {
   install: 'pnpm dlx shadcn@latest add @nebari/code-block',
-  usage: `import { CodeBlock, CodeBlockBody } from '@/ui/code-block';
+  usage: `import { CodeBlock, CodeBlockBody } from '@/components/ui/code-block';
 
 export function Example() {
   return (

--- a/stories/use-drawer-context.stories.tsx
+++ b/stories/use-drawer-context.stories.tsx
@@ -1,8 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Fragment, useState } from 'react';
 import { expect, userEvent, waitFor, within } from 'storybook/test';
-import { Alert, AlertDescription, AlertTitle } from '@/ui/alert';
-import { Button } from '@/ui/button';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
 import {
   Drawer,
   DrawerBody,
@@ -16,7 +16,7 @@ import {
   DrawerTitle,
   DrawerTrigger,
   useDrawerContext,
-} from '@/ui/drawer';
+} from '@/components/ui/drawer';
 
 const SIDES: DrawerSide[] = ['right', 'bottom', 'left', 'top'];
 

--- a/stories/use-sidebar.stories.tsx
+++ b/stories/use-sidebar.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Home, Settings } from 'lucide-react';
 import { expect, userEvent, within } from 'storybook/test';
-import { Button } from '@/ui/button';
+import { Button } from '@/components/ui/button';
 import {
   Sidebar,
   SidebarContent,
@@ -14,7 +14,7 @@ import {
   SidebarProvider,
   type SidebarState,
   useSidebar,
-} from '@/ui/sidebar';
+} from '@/components/ui/sidebar';
 
 interface UseSidebarDemoProps {
   /** Documentation-only row for the `useSidebar` return value. */

--- a/stories/use-theme-preference.stories.tsx
+++ b/stories/use-theme-preference.stories.tsx
@@ -1,12 +1,12 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useEffect } from 'react';
 import { expect, userEvent, within } from 'storybook/test';
+import { Button } from '@/components/ui/button';
 import {
   THEME_MODES,
   type ThemeMode,
   useThemePreference,
 } from '@/hooks/use-theme-preference';
-import { Button } from '@/ui/button';
 import {
   THEME_MODE_LABELS,
   useReturnThemeToToolbar,

--- a/tests/accordion.test.tsx
+++ b/tests/accordion.test.tsx
@@ -7,7 +7,7 @@ import {
   AccordionContent,
   AccordionItem,
   AccordionTrigger,
-} from '@/ui/accordion';
+} from '@/components/ui/accordion';
 import accordionMeta, {
   Default as AccordionDefaultStory,
 } from '../stories/accordion.stories';

--- a/tests/alert.test.tsx
+++ b/tests/alert.test.tsx
@@ -7,7 +7,7 @@ import {
   AlertDescription,
   AlertTitle,
   alertVariants,
-} from '@/ui/alert';
+} from '@/components/ui/alert';
 
 describe('Alert', () => {
   it('renders a polite status region with default slot/variant attributes', () => {

--- a/tests/badge.test.tsx
+++ b/tests/badge.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
-import { Badge, badgeVariants } from '@/ui/badge';
+import { Badge, badgeVariants } from '@/components/ui/badge';
 
 describe('Badge', () => {
   it('renders its children with default variant data attributes', () => {

--- a/tests/breadcrumb.test.tsx
+++ b/tests/breadcrumb.test.tsx
@@ -13,7 +13,7 @@ import {
   BreadcrumbList,
   BreadcrumbPage,
   BreadcrumbSeparator,
-} from '@/ui/breadcrumb';
+} from '@/components/ui/breadcrumb';
 
 describe('Breadcrumb', () => {
   it('renders a labelled breadcrumb navigation landmark', () => {

--- a/tests/button-group.test.tsx
+++ b/tests/button-group.test.tsx
@@ -1,13 +1,13 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
-import { Button } from '@/ui/button';
+import { Button } from '@/components/ui/button';
 import {
   ButtonGroup,
   ButtonGroupSeparator,
   ButtonGroupText,
   buttonGroupVariants,
-} from '@/ui/button-group';
+} from '@/components/ui/button-group';
 
 describe('ButtonGroup', () => {
   it('renders a labeled horizontal group by default', () => {

--- a/tests/button.test.tsx
+++ b/tests/button.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
-import { Button, buttonVariants } from '@/ui/button';
+import { Button, buttonVariants } from '@/components/ui/button';
 
 describe('Button', () => {
   it('renders a button with default variant/size data attributes', () => {

--- a/tests/calendar.test.tsx
+++ b/tests/calendar.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
-import { Calendar, Day, dayVariants } from '@/ui/calendar';
+import { Calendar, Day, dayVariants } from '@/components/ui/calendar';
 
 const july2026 = new Date(2026, 6, 1);
 const july3 = new Date(2026, 6, 3);

--- a/tests/card.test.tsx
+++ b/tests/card.test.tsx
@@ -9,7 +9,7 @@ import {
   CardHeader,
   CardTitle,
   cardVariants,
-} from '@/ui/card';
+} from '@/components/ui/card';
 
 describe('Card', () => {
   it('renders the composed card structure with stable data hooks', () => {

--- a/tests/checkbox.test.tsx
+++ b/tests/checkbox.test.tsx
@@ -6,7 +6,7 @@ import {
   CheckboxGroup,
   checkboxGroupVariants,
   checkboxVariants,
-} from '@/ui/checkbox';
+} from '@/components/ui/checkbox';
 
 describe('Checkbox', () => {
   it('renders a vertical checkbox group by default', () => {

--- a/tests/code-block.test.tsx
+++ b/tests/code-block.test.tsx
@@ -8,7 +8,7 @@ import {
   CodeBlockHeader,
   codeBlockCopyButtonVariants,
   useCodeBlockContext,
-} from '@/ui/code-block';
+} from '@/components/ui/code-block';
 
 const snippet = 'const answer = 42;\n\nconsole.log(answer);';
 

--- a/tests/combobox.test.tsx
+++ b/tests/combobox.test.tsx
@@ -16,8 +16,8 @@ import {
   ComboboxList,
   ComboboxSeparator,
   ComboboxValue,
-} from '@/ui/combobox';
-import { Field, FieldLabel } from '@/ui/field';
+} from '@/components/ui/combobox';
+import { Field, FieldLabel } from '@/components/ui/field';
 
 interface Framework {
   label: string;

--- a/tests/data-table.test.tsx
+++ b/tests/data-table.test.tsx
@@ -1,8 +1,8 @@
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
-import { Button } from '@/ui/button';
-import { DataTable, type DataTableColumnDef } from '@/ui/data-table';
+import { Button } from '@/components/ui/button';
+import { DataTable, type DataTableColumnDef } from '@/components/ui/data-table';
 
 type Project = {
   id: string;

--- a/tests/date-picker.test.tsx
+++ b/tests/date-picker.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
-import { DatePicker, datePickerVariants } from '@/ui/date-picker';
+import { DatePicker, datePickerVariants } from '@/components/ui/date-picker';
 
 const july2026 = new Date(2026, 6, 1);
 const july6 = new Date(2026, 6, 6);

--- a/tests/dialog.test.tsx
+++ b/tests/dialog.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
-import { Button } from '@/ui/button';
+import { Button } from '@/components/ui/button';
 import {
   Dialog,
   DialogClose,
@@ -11,7 +11,7 @@ import {
   DialogHeader,
   DialogTitle,
   DialogTrigger,
-} from '@/ui/dialog';
+} from '@/components/ui/dialog';
 
 function TestDialog({
   onOpenChange,

--- a/tests/drawer.test.tsx
+++ b/tests/drawer.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
-import { Button } from '@/ui/button';
+import { Button } from '@/components/ui/button';
 import {
   Drawer,
   DrawerBody,
@@ -14,7 +14,7 @@ import {
   DrawerTitle,
   DrawerTrigger,
   useDrawerContext,
-} from '@/ui/drawer';
+} from '@/components/ui/drawer';
 
 function DrawerContextProbe() {
   const { hasSnapPoints, modal, showSwipeHandle, side, swipeDirection } =

--- a/tests/dropdown-menu.test.tsx
+++ b/tests/dropdown-menu.test.tsx
@@ -10,7 +10,7 @@ import {
   DropdownMenuPortal,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
-} from '@/ui/dropdown-menu';
+} from '@/components/ui/dropdown-menu';
 
 interface TestDropdownMenuProps {
   onFirstSelect?: () => void;

--- a/tests/field.test.tsx
+++ b/tests/field.test.tsx
@@ -1,8 +1,13 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it } from 'vitest';
-import { Field, FieldDescription, FieldError, FieldLabel } from '@/ui/field';
-import { Switch } from '@/ui/switch';
+import {
+  Field,
+  FieldDescription,
+  FieldError,
+  FieldLabel,
+} from '@/components/ui/field';
+import { Switch } from '@/components/ui/switch';
 
 describe('Field', () => {
   it('names the control via its label', () => {

--- a/tests/input.test.tsx
+++ b/tests/input.test.tsx
@@ -1,9 +1,9 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it } from 'vitest';
-import { Field, FieldLabel } from '@/ui/field';
-import { Input } from '@/ui/input';
-import { Label } from '@/ui/label';
+import { Field, FieldLabel } from '@/components/ui/field';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
 
 // CSS transitions are not testable in jsdom; animated/hover/focus visuals are
 // verified in Storybook.

--- a/tests/label.test.tsx
+++ b/tests/label.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
-import { Label } from '@/ui/label';
+import { Label } from '@/components/ui/label';
 
 describe('Label', () => {
   it('renders its children with the base classes and data-slot', () => {

--- a/tests/navigation-menu.test.tsx
+++ b/tests/navigation-menu.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
-import { DropdownMenuItem } from '@/ui/dropdown-menu';
+import { DropdownMenuItem } from '@/components/ui/dropdown-menu';
 import {
   MenuBar,
   MenuBarActions,
@@ -10,7 +10,7 @@ import {
   NavDropdownMenu,
   NavLink,
   navLinkVariants,
-} from '@/ui/navigation-menu';
+} from '@/components/ui/navigation-menu';
 
 describe('NavigationMenu', () => {
   it('renders a full menu bar with anchor-first navigation links', () => {

--- a/tests/radio-group.test.tsx
+++ b/tests/radio-group.test.tsx
@@ -1,13 +1,13 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
-import { Field, FieldError, FieldLabel } from '@/ui/field';
+import { Field, FieldError, FieldLabel } from '@/components/ui/field';
 import {
   RadioGroup,
   RadioGroupItem,
   radioGroupItemVariants,
   radioGroupVariants,
-} from '@/ui/radio-group';
+} from '@/components/ui/radio-group';
 
 describe('RadioGroup', () => {
   it('renders an unselected item with stable data hooks', () => {

--- a/tests/select.test.tsx
+++ b/tests/select.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { ComponentProps } from 'react';
 import { describe, expect, it, vi } from 'vitest';
-import { Field, FieldLabel } from '@/ui/field';
+import { Field, FieldLabel } from '@/components/ui/field';
 import {
   Select,
   SelectContent,
@@ -12,7 +12,7 @@ import {
   SelectSeparator,
   SelectTrigger,
   SelectValue,
-} from '@/ui/select';
+} from '@/components/ui/select';
 
 const frameworks = [
   { label: 'Next.js', value: 'next' },

--- a/tests/sidebar.test.tsx
+++ b/tests/sidebar.test.tsx
@@ -8,7 +8,7 @@ import {
   DropdownMenuItem,
   DropdownMenuPortal,
   DropdownMenuTrigger,
-} from '@/ui/dropdown-menu';
+} from '@/components/ui/dropdown-menu';
 import {
   Sidebar,
   SidebarContent,
@@ -26,7 +26,7 @@ import {
   SidebarProvider,
   SidebarSeparator,
   SidebarTrigger,
-} from '@/ui/sidebar';
+} from '@/components/ui/sidebar';
 
 function SidebarHarness({
   collapsed,

--- a/tests/skeleton.test.tsx
+++ b/tests/skeleton.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
-import { Skeleton, skeletonVariants } from '@/ui/skeleton';
+import { Skeleton, skeletonVariants } from '@/components/ui/skeleton';
 
 describe('Skeleton', () => {
   it('renders a decorative line by default', () => {

--- a/tests/slider.test.tsx
+++ b/tests/slider.test.tsx
@@ -1,7 +1,7 @@
 import { act, render } from '@testing-library/react';
 import type { ReactElement } from 'react';
 import { describe, expect, it } from 'vitest';
-import { Slider } from '@/ui/slider';
+import { Slider } from '@/components/ui/slider';
 
 async function renderSlider(ui: ReactElement) {
   const result = render(ui);

--- a/tests/spinner.test.tsx
+++ b/tests/spinner.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
-import { Spinner, spinnerVariants } from '@/ui/spinner';
+import { Spinner, spinnerVariants } from '@/components/ui/spinner';
 
 describe('Spinner', () => {
   it('renders with the status role and default slot/size attributes', () => {

--- a/tests/ssr.test.tsx
+++ b/tests/ssr.test.tsx
@@ -54,7 +54,7 @@ describe('SSR safety — every registry:ui component', () => {
     const componentName = toPascalCase(item.name);
 
     it(`${item.name} (${componentName}) renders to non-empty HTML without useLayoutEffect warnings`, async () => {
-      const mod = await import(`@/ui/${item.name}.tsx`);
+      const mod = await import(`@/components/ui/${item.name}.tsx`);
       const Component = mod[componentName] as React.ComponentType | undefined;
 
       expect(

--- a/tests/switch.test.tsx
+++ b/tests/switch.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
-import { Switch } from '@/ui/switch';
+import { Switch } from '@/components/ui/switch';
 
 describe('Switch', () => {
   it('renders a switch role', () => {

--- a/tests/table.test.tsx
+++ b/tests/table.test.tsx
@@ -11,7 +11,7 @@ import {
   TableHead,
   TableHeader,
   TableRow,
-} from '@/ui/table';
+} from '@/components/ui/table';
 
 function TestTable() {
   return (

--- a/tests/tabs.test.tsx
+++ b/tests/tabs.test.tsx
@@ -10,7 +10,7 @@ import {
   tabsIndicatorVariants,
   tabsListVariants,
   tabsTabVariants,
-} from '@/ui/tabs';
+} from '@/components/ui/tabs';
 
 function renderTabs(variant: 'pill' | 'underline' = 'pill') {
   return render(

--- a/tests/textarea.test.tsx
+++ b/tests/textarea.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it } from 'vitest';
-import { Textarea } from '@/ui/textarea';
+import { Textarea } from '@/components/ui/textarea';
 
 // CSS transitions are not testable in jsdom; animated/hover/focus visuals are
 // verified in Storybook.

--- a/tests/toast.test.tsx
+++ b/tests/toast.test.tsx
@@ -21,7 +21,7 @@ import {
   ToastProvider,
   ToastTitle,
   useToastManager,
-} from '@/ui/toast';
+} from '@/components/ui/toast';
 
 /**
  * These tests assert the component's public contract only — ARIA roles and

--- a/tests/tooltip.test.tsx
+++ b/tests/tooltip.test.tsx
@@ -6,7 +6,7 @@ import {
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
-} from '@/ui/tooltip';
+} from '@/components/ui/tooltip';
 
 function TestTooltip({
   defaultOpen,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
     "isolatedModules": true,
     "verbatimModuleSyntax": true,
     "paths": {
+      "@/components/ui/*": ["./registry/nebari/ui/*"],
       "@/*": ["./registry/nebari/*"]
     }
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,6 +6,10 @@ export default defineConfig({
   plugins: [tailwindcss()],
   resolve: {
     alias: {
+      // Registry sources import siblings as `@/components/ui/<name>` — the
+      // path the shadcn CLI emits for a consumer's default aliases — so map
+      // that prefix onto `registry/nebari/ui` ahead of the `@/*` catch-all.
+      '@/components/ui': resolve(__dirname, './registry/nebari/ui'),
       '@': resolve(__dirname, './registry/nebari'),
     },
   },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,7 +5,13 @@ import react from '@vitejs/plugin-react';
 import { playwright } from '@vitest/browser-playwright';
 import { defineConfig } from 'vitest/config';
 
-const alias = { '@': resolve(__dirname, './registry/nebari') };
+// Registry sources import siblings as `@/components/ui/<name>` — the path the
+// shadcn CLI emits for a consumer's default aliases — so map that prefix onto
+// `registry/nebari/ui` ahead of the `@/*` catch-all.
+const alias = {
+  '@/components/ui': resolve(__dirname, './registry/nebari/ui'),
+  '@': resolve(__dirname, './registry/nebari'),
+};
 
 export default defineConfig({
   resolve: { alias },


### PR DESCRIPTION
Closes #153

## Summary

Eleven registry components (`button`, `calendar`, `combobox`, `data-table`, `date-picker`, `dialog`, `drawer`, `dropdown-menu`, `navigation-menu`, `sidebar`, `toast`) imported siblings via `@/ui/<name>`. The shadcn CLI rewrites that to `@/components/ui/<name>` in every consumer using the default aliases, so installed files always differed from `registry/nebari/ui/<name>.tsx` by one import line each and the #143 byte-identical check could never pass for them.

This PR switches the registry to the alias the CLI emits and makes the repo resolve it.

- **Registry sources** import siblings as `@/components/ui/<name>` (17 lines across the 11 files). The CLI passes this through unchanged for default aliases and remaps it correctly for consumers with a custom `ui` alias.
- **Stories and tests** use the same convention, so the repo has one import style. This is the bulk of the diff and is mechanical (`sed` + Biome import ordering).
- **Resolution**: `@/components/ui/*` → `registry/nebari/ui/*` is added ahead of the `@/*` catch-all in `tsconfig.json`, `vite.config.ts`, `vitest.config.ts`, and `.storybook/main.ts`. `components.json`'s `ui` alias now points at `@/components/ui`.
- **Guardrail**: a Biome `noRestrictedImports` rule rejects `@/ui/*`, so a regression fails `bun run check` instead of relying on a grep.
- **Docs**: AGENTS.md, README, the contributor skill, and the consumer skill describe the new alias and the reason for it.

## Acceptance criteria

- [x] Registry sources import siblings via the alias the CLI emits for the default `components.json`
- [x] `components.json` / `tsconfig.json` (plus Vite, Vitest, Storybook) resolve the new import paths
- [x] `grep -rn "from '@/ui/" registry/nebari/ui` returns nothing (and Biome now enforces it)
- [x] A fresh `shadcn add @nebari/button` into a default-alias consumer is byte-identical to the registry source after the consumer's formatter (see below)
- [x] `bun run check`, `bun run test`, and `bun run build:registry` pass

## Verification

`bun run check`, `bun run ci`, `bunx tsc --noEmit`, `bun run build:registry`, and `bun run test` (78 files, 911 tests) all pass locally.

End-to-end: scaffolded a throwaway consumer with the default aliases, served the built `public/r` locally as the `@nebari` registry, and ran `shadcn@4.19.0 add` for all eleven components. After the consumer's Biome format, every installed file (including transitive deps and `lib/utils.ts`, `lib/date.ts`) is byte-identical to its registry source. The only differences are the dropped `// biome-ignore-all` header on `calendar.tsx` and `table.tsx`, which the issue scopes out as a separate CLI transform problem.

## Out of scope

- The `// biome-ignore-all` header loss on install (separate CLI issue).
- Re-syncing consumer repos (tracked per repo under #143).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X7pio1M3PmRwFuX5F85ngG
