### PR TITLE
Move Biome suppressions inline so the shadcn CLI preserves them

### DIFF
--- a/registry/nebari/ui/calendar.tsx
+++ b/registry/nebari/ui/calendar.tsx
@@ -1,4 +1,3 @@
-// biome-ignore-all lint/a11y/noNoninteractiveElementToInteractiveRole: Calendar uses the WAI-ARIA date-picker grid pattern.
 import { useRender } from '@base-ui/react/use-render';
 import { cva, type VariantProps } from 'class-variance-authority';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
@@ -572,6 +571,7 @@ function Calendar({
             className="w-[15.75rem] table-fixed border-collapse"
             data-slot="calendar-grid"
             ref={gridRef}
+            // biome-ignore lint/a11y/noNoninteractiveElementToInteractiveRole: Calendar uses the WAI-ARIA date-picker grid pattern.
             role="grid"
           >
             <thead>
@@ -611,6 +611,7 @@ function Calendar({
                         data-outside={cell.outside || undefined}
                         data-variant={state}
                         key={formatDateKey(cell.date)}
+                        // biome-ignore lint/a11y/noNoninteractiveElementToInteractiveRole: Calendar uses the WAI-ARIA date-picker grid pattern.
                         role="gridcell"
                         tabIndex={-1}
                       >

--- a/registry/nebari/ui/table.tsx
+++ b/registry/nebari/ui/table.tsx
@@ -1,4 +1,3 @@
-// biome-ignore-all lint/a11y/noNoninteractiveTabindex: table scroll containers need keyboard access when content overflows.
 import type * as React from 'react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { cn } from '@/lib/utils';


### PR DESCRIPTION
Fixes #154

## Problem

The shadcn CLI's import-rewrite transform drops any comment placed above the first `import`, so the file-leading `// biome-ignore-all ...` in `table.tsx` and `calendar.tsx` was stripped on install. Consumers linting `components/ui/` with Biome failed, and the installed file was not byte-identical to the registry source. All six #143 consumer PRs patched it back by hand.

## Change

- **`calendar.tsx`**: replace the leading `biome-ignore-all` with inline `// biome-ignore lint/a11y/noNoninteractiveElementToInteractiveRole` comments on the two attributes Biome actually flags (`role="grid"` on the `<table>` and `role="gridcell"` on the `<td>`). Inline suppressions sit inside the JSX and survive the CLI transform.
- **`table.tsx`**: drop the leading `biome-ignore-all` entirely. Biome's `noNoninteractiveTabindex` only reports literal `tabIndex` values, and every `tabIndex` in the file is a dynamic expression, so the suppression never fired. Removing the comment produces zero diagnostics.

## Verification

- `bun run check` clean (the one remaining "info" is the pre-existing biome.json schema-version note).
- `vitest run tests/table tests/calendar`: 18 tests pass.
- Built the registry, served `public/r` locally, and ran `npx shadcn@4.21.0 add --overwrite --yes @nebari/table @nebari/calendar` into a scratch Tailwind v4 consumer:
  - `cmp` against `registry/nebari/ui/table.tsx` and `calendar.tsx` reports no difference.
  - `biome lint` on the installed files passes with this repo's config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X7pio1M3PmRwFuX5F85ngG
